### PR TITLE
Custom UserStore ad RoleStore for MongoDb

### DIFF
--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
-    [IdentityDefaultUI(typeof(ConfirmEmailModel<>))]
+    [IdentityDefaultUI(typeof(ConfirmEmailModel<,>))]
     public abstract class ConfirmEmailModel : PageModel
     {
         [TempData]
@@ -17,7 +17,9 @@ namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
         public virtual Task<IActionResult> OnGetAsync(string userId, string code) => throw new NotImplementedException();
     }
 
-    public class ConfirmEmailModel<TUser> : ConfirmEmailModel where TUser : IdentityUser<Guid>, new()
+    public class ConfirmEmailModel<TUser, TKey> : ConfirmEmailModel 
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly UserManager<TUser> userManager;
         private readonly ILogger<ConfirmEmailModel> logger;

--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -11,7 +11,7 @@ using System.Text.Encodings.Web;
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
-    [IdentityDefaultUI(typeof(ExternalLoginModel<>))]
+    [IdentityDefaultUI(typeof(ExternalLoginModel<,>))]
     public class ExternalLoginModel : PageModel
     {
         [BindProperty]
@@ -40,7 +40,9 @@ namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
         public virtual Task<IActionResult> OnPostConfirmationAsync(string returnUrl = null) => throw new NotImplementedException();
     }
 
-    public class ExternalLoginModel<TUser> : ExternalLoginModel where TUser : IdentityUser<Guid>, new()
+    public class ExternalLoginModel<TUser, TKey> : ExternalLoginModel 
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly SignInManager<TUser> signInManager;
         private readonly UserManager<TUser> userManager;

--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -8,7 +8,7 @@ using System.ComponentModel.DataAnnotations;
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
-    [IdentityDefaultUI(typeof(LoginModel<>))]
+    [IdentityDefaultUI(typeof(LoginModel<,>))]
     public abstract class LoginModel : PageModel
     {
         [BindProperty]
@@ -41,7 +41,10 @@ namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
         public virtual Task<IActionResult> OnPostAsync(string returnUrl = null) => throw new NotImplementedException();
     }
 
-    public class LoginModel<TUser> : LoginModel where TUser : IdentityUser<Guid>, new()
+    public class LoginModel<TUser, TKey> : LoginModel 
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
+
     {
         private readonly SignInManager<TUser> signInManager;
         private readonly ILogger<LoginModel> logger;

--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/LoginWith2fa.cshtml.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
-    [IdentityDefaultUI(typeof(LoginWith2faModel<>))]
+    [IdentityDefaultUI(typeof(LoginWith2faModel<,>))]
     public abstract class LoginWith2faModel : PageModel
     {
         [BindProperty]
@@ -35,7 +35,9 @@ namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
         public virtual Task<IActionResult> OnPostAsync(bool rememberMe, string returnUrl = null) => throw new NotImplementedException();
     }
 
-    public class LoginWith2faModel<TUser> : LoginWith2faModel where TUser : IdentityUser<Guid>, new()
+    public class LoginWith2faModel<TUser, TKey> : LoginWith2faModel
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly SignInManager<TUser> signInManager;
         private readonly UserManager<TUser> userManager;

--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/LoginWithRecoveryCode.cshtml.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
-    [IdentityDefaultUI(typeof(LoginWithRecoveryCodeModel<>))]
+    [IdentityDefaultUI(typeof(LoginWithRecoveryCodeModel<,>))]
     public abstract class LoginWithRecoveryCodeModel : PageModel
     {
         [BindProperty]
@@ -29,7 +29,9 @@ namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
         public virtual Task<IActionResult> OnPostAsync(string returnUrl = null) => throw new NotImplementedException();
     }
 
-    public class LoginWithRecoveryCodeModel<TUser> : LoginWithRecoveryCodeModel where TUser : IdentityUser<Guid>, new()
+    public class LoginWithRecoveryCodeModel<TUser, TKey> : LoginWithRecoveryCodeModel 
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly SignInManager<TUser> signInManager;
         private readonly UserManager<TUser> userManager;

--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -11,7 +11,7 @@ using System.Text.Encodings.Web;
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
-    [IdentityDefaultUI(typeof(RegisterModel<>))]
+    [IdentityDefaultUI(typeof(RegisterModel<,>))]
     public abstract class RegisterModel : PageModel
     {
 
@@ -46,7 +46,9 @@ namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
         public virtual Task<IActionResult> OnPostAsync(string returnUrl = null) => throw new NotImplementedException();
     }
 
-    public class RegisterModel<TUser> : RegisterModel where TUser : class
+    public class RegisterModel<TUser, TKey> : RegisterModel 
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly SignInManager<TUser> signInManager;
         private readonly UserManager<TUser> userManager;

--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
-    [IdentityDefaultUI(typeof(RegisterConfirmationModel<>))]
+    [IdentityDefaultUI(typeof(RegisterConfirmationModel<,>))]
     public class RegisterConfirmationModel : PageModel
     {
         public string Email { get; set; }
@@ -18,7 +18,9 @@ namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
         public virtual Task<IActionResult> OnGetAsync(string email, string returnUrl = null) => throw new NotImplementedException();
     }
 
-    public class RegisterConfirmationModel<TUser> : RegisterConfirmationModel where TUser : class
+    public class RegisterConfirmationModel<TUser, TKey> : RegisterConfirmationModel
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly UserManager<TUser> userManager;      
         

--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -9,6 +9,7 @@ using System.Text;
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
 {
     [AllowAnonymous]
+    [IdentityDefaultUI(typeof(ResetPasswordModel<,>))]
     public abstract class ResetPasswordModel : PageModel
     {
         [BindProperty]
@@ -40,7 +41,9 @@ namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
         public virtual Task<IActionResult> OnPostAsync() => throw new NotImplementedException();
     }
 
-    public class ResetPasswordModel<TUser> : ResetPasswordModel where TUser : IdentityUser<Guid>, new()
+    public class ResetPasswordModel<TUser, TKey> : ResetPasswordModel 
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly UserManager<TUser> userManager;
 

--- a/src/Pixel.Identity.Core/Controllers/AccountController.cs
+++ b/src/Pixel.Identity.Core/Controllers/AccountController.cs
@@ -15,8 +15,9 @@ namespace Pixel.Identity.Core.Controllers
     /// <typeparam name="TUser"></typeparam>
     [Route("api/[controller]")]
     [ApiController]
-    public class AccountController<TUser> : Controller 
-        where TUser : IdentityUser<Guid>, new()
+    public class AccountController<TUser, TKey> : Controller 
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly UserManager<TUser> userManager;
         private readonly SignInManager<TUser> signInManager;

--- a/src/Pixel.Identity.Core/Controllers/AuthenticatorController.cs
+++ b/src/Pixel.Identity.Core/Controllers/AuthenticatorController.cs
@@ -12,8 +12,9 @@ namespace Pixel.Identity.Core.Controllers
     /// Api endpoint for managing 2fa authentication for user account
     /// </summary>
     /// <typeparam name="TUser"></typeparam>  
-    public class AuthenticatorController<TUser> : Controller 
-        where TUser : IdentityUser<Guid>, new ()
+    public class AuthenticatorController<TUser, TKey> : Controller
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private const string AuthenticatorUriFormat = "otpauth://totp/{0}:{1}?secret={2}&issuer={0}&digits=6";
 

--- a/src/Pixel.Identity.Core/Controllers/AuthorizationController.cs
+++ b/src/Pixel.Identity.Core/Controllers/AuthorizationController.cs
@@ -25,8 +25,9 @@ namespace Pixel.Identity.Core.Controllers
     /// Controller for handling OpenId protocol using OpenIdDict. It provides end points for authentication, tokens, sign out , etc.
     /// It must be inherited in the DbStore plugin which should provide it with the desired type for TUser
     /// </summary>
-    public abstract class AuthorizationController<TUser> : Controller
-        where TUser : IdentityUser<Guid>, new()
+    public abstract class AuthorizationController<TUser, TKey> : Controller
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly IOpenIddictApplicationManager _applicationManager;
         private readonly IOpenIddictAuthorizationManager _authorizationManager;

--- a/src/Pixel.Identity.Core/Controllers/ExternalLoginsController.cs
+++ b/src/Pixel.Identity.Core/Controllers/ExternalLoginsController.cs
@@ -8,13 +8,14 @@ namespace Pixel.Identity.Core.Controllers
     [Authorize]
     [Route("api/[controller]")]
     [ApiController]
-    public class ExternalLoginsController<TUser> : Controller
-        where TUser : IdentityUser<Guid>, new()
+    public class ExternalLoginsController<TUser, TKey> : Controller
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly UserManager<TUser> userManager;
         private readonly SignInManager<TUser> signInManager;
         private readonly IUserStore<TUser> userStore;
-        private readonly ILogger<ExternalLoginsController<TUser>> logger;
+        private readonly ILogger<ExternalLoginsController<TUser, TKey>> logger;
 
         /// <summary>
         /// constructor
@@ -23,7 +24,7 @@ namespace Pixel.Identity.Core.Controllers
         /// <param name="signInManager"></param>       
         public ExternalLoginsController(UserManager<TUser> userManager,
             SignInManager<TUser> signInManager, IUserStore<TUser> userStore,
-            ILogger<ExternalLoginsController<TUser>> logger)
+            ILogger<ExternalLoginsController<TUser, TKey>> logger)
         {
             this.userManager = userManager;
             this.signInManager = signInManager;

--- a/src/Pixel.Identity.Core/Controllers/RolesController.cs
+++ b/src/Pixel.Identity.Core/Controllers/RolesController.cs
@@ -16,9 +16,10 @@ namespace Pixel.Identity.Core.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [Authorize(Policy = Policies.CanManageRoles)]
-    public class RolesController<TUser, TRole> : ControllerBase
-        where TUser : IdentityUser<Guid>, new()
-        where TRole : IdentityRole<Guid>, new()
+    public class RolesController<TUser, TRole, TKey> : ControllerBase
+        where TUser : IdentityUser<TKey>, new()
+        where TRole : IdentityRole<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly RoleManager<TRole> roleManager;
         private readonly UserManager<TUser> userManager;
@@ -47,7 +48,7 @@ namespace Pixel.Identity.Core.Controllers
                 var role = await this.roleManager.FindByNameAsync(roleName);
                 if (role != null)
                 {
-                    var userRoleViewModel = new UserRoleViewModel(role.Id, role.Name);
+                    var userRoleViewModel = new UserRoleViewModel(role.Id.ToString(), role.Name);
                     var claims = await this.roleManager.GetClaimsAsync(role) ?? Enumerable.Empty<Claim>();
                     foreach (var claim in claims)
                     {
@@ -82,7 +83,7 @@ namespace Pixel.Identity.Core.Controllers
             }
             foreach (var role in roles)
             {
-                userRoles.Add(new UserRoleViewModel(role.Id, role.Name));
+                userRoles.Add(new UserRoleViewModel(role.Id.ToString(), role.Name));
             }
             return new PagedList<UserRoleViewModel>(userRoles, count, getRolesRequest.CurrentPage, getRolesRequest.PageSize);
         }

--- a/src/Pixel.Identity.Core/Controllers/UserInfoController.cs
+++ b/src/Pixel.Identity.Core/Controllers/UserInfoController.cs
@@ -14,8 +14,9 @@ namespace Pixel.Identity.Core.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    public class UserinfoController<TUser> : Controller
-        where TUser : IdentityUser<Guid>, new()
+    public class UserinfoController<TUser, TKey> : Controller
+        where TUser : IdentityUser<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         private readonly UserManager<TUser> userManager;
 

--- a/src/Pixel.Identity.Core/Controllers/UsersController.cs
+++ b/src/Pixel.Identity.Core/Controllers/UsersController.cs
@@ -16,8 +16,9 @@ namespace Pixel.Identity.Core.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [Authorize]    
-    public class UsersController<TUser> : Controller
-        where TUser : IdentityUser<Guid>, new()
+    public class UsersController<TUser, TKey> : Controller
+        where TUser : IdentityUser<TKey>, new()
+        where TKey :  IEquatable<TKey>
     {
         private readonly IMapper mapper;
         private readonly UserManager<TUser> userManager;

--- a/src/Pixel.Identity.Core/Conventions/IdentityPageModelConvention.cs
+++ b/src/Pixel.Identity.Core/Conventions/IdentityPageModelConvention.cs
@@ -3,7 +3,9 @@ using System.Reflection;
 
 namespace Pixel.Identity.Core.Conventions
 {
-    public class IdentityPageModelConvention<TUser> : IPageApplicationModelConvention where TUser : class
+    public class IdentityPageModelConvention<TUser, TKey> : IPageApplicationModelConvention
+        where TUser : class
+        where TKey : IEquatable<TKey>
     {
         public void Apply(PageApplicationModel model)
         {
@@ -14,7 +16,7 @@ namespace Pixel.Identity.Core.Conventions
             }
 
             ValidateTemplate(defaultUIAttribute.Template);
-            var templateInstance = defaultUIAttribute.Template.MakeGenericType(typeof(TUser));
+            var templateInstance = defaultUIAttribute.Template.MakeGenericType(typeof(TUser), typeof(TKey));
             model.ModelType = templateInstance.GetTypeInfo();
         }
 
@@ -25,7 +27,7 @@ namespace Pixel.Identity.Core.Conventions
                 throw new InvalidOperationException("Implementation type can't be abstract or non generic.");
             }
             var genericArguments = template.GetGenericArguments();
-            if (genericArguments.Length != 1)
+            if (genericArguments.Length != 2)
             {
                 throw new InvalidOperationException("Implementation type contains wrong generic arity.");
             }

--- a/src/Pixel.Identity.Shared/ViewModels/UserRoleViewModel.cs
+++ b/src/Pixel.Identity.Shared/ViewModels/UserRoleViewModel.cs
@@ -6,8 +6,8 @@ namespace Pixel.Identity.Shared.ViewModels
 {
     public class UserRoleViewModel
     {
-        [Required]     
-        public Guid RoleId { get; set; }
+        [Required(AllowEmptyStrings = true)]
+        public string RoleId { get; set; }
 
         [Required]       
         public string RoleName { get; set; }
@@ -15,7 +15,7 @@ namespace Pixel.Identity.Shared.ViewModels
         [Required]       
         public List<ClaimViewModel> Claims { get; set; } = new List<ClaimViewModel>();
 
-        public bool Exists => !Guid.Empty.Equals(RoleId);
+        public bool Exists => !string.IsNullOrEmpty(RoleId);
 
         public UserRoleViewModel()
         {
@@ -23,11 +23,12 @@ namespace Pixel.Identity.Shared.ViewModels
         }
 
         public UserRoleViewModel(string roleName)
-        {          
+        {
+            this.RoleId = string.Empty;
             this.RoleName = roleName;
         }
 
-        public UserRoleViewModel(Guid roleId, string roleName) : this(roleName)
+        public UserRoleViewModel(string roleId, string roleName) : this(roleName)
         {
             this.RoleId = roleId;         
         }

--- a/src/Pixel.Identity.Store.Mongo/Areas/Identity/Pages/Shared/_LoginPartial.cshtml
+++ b/src/Pixel.Identity.Store.Mongo/Areas/Identity/Pages/Shared/_LoginPartial.cshtml
@@ -1,5 +1,6 @@
 ﻿@using Microsoft.AspNetCore.Identity
 @using Pixel.Identity.Store.Mongo
+@using Pixel.Identity.Store.Mongo.Models
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/Pixel.Identity.Store.Mongo/AutoMapProfile.cs
+++ b/src/Pixel.Identity.Store.Mongo/AutoMapProfile.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using OpenIddict.Abstractions;
 using OpenIddict.MongoDb.Models;
 using Pixel.Identity.Shared.ViewModels;
+using Pixel.Identity.Store.Mongo.Models;
 
 namespace Pixel.Identity.Store.Mongo
 {
@@ -20,11 +21,12 @@ namespace Pixel.Identity.Store.Mongo
             .ForMember(d => d.Id, opt => opt.MapFrom(s => s.Id.ToString()))
             .ForMember(d => d.IsConfidentialClient, opt => opt.Ignore());
 
-            CreateMap<IdentityUser<Guid>, UserDetailsViewModel>()
+            CreateMap<ApplicationUser, UserDetailsViewModel>()
+             .ForMember(d => d.Id, opt => opt.MapFrom(s => s.Id.ToString()))
              .ForMember(d => d.UserRoles, opt => opt.Ignore())
              .ForMember(d => d.UserClaims, opt => opt.Ignore());
 
-            CreateMap<IdentityRole<Guid>, UserRoleViewModel>()
+            CreateMap<ApplicationRole, UserRoleViewModel>()
             .ForMember(d => d.RoleId, opt => opt.MapFrom(s => s.Id))
             .ForMember(d => d.RoleName, opt => opt.MapFrom(s => s.Name))
             .ForMember(d => d.Claims, opt => opt.Ignore());

--- a/src/Pixel.Identity.Store.Mongo/Contracts/IDocument.cs
+++ b/src/Pixel.Identity.Store.Mongo/Contracts/IDocument.cs
@@ -1,0 +1,15 @@
+﻿namespace Pixel.Identity.Store.Mongo.Contracts
+{   
+    public interface IDocument<TKey> where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        /// Identifier for the document
+        /// </summary>
+        TKey Id { get; set; }
+
+        /// <summary>
+        /// Version of the document
+        /// </summary>
+        int Version { get; set; }
+    }
+}

--- a/src/Pixel.Identity.Store.Mongo/Controllers/AccountController.cs
+++ b/src/Pixel.Identity.Store.Mongo/Controllers/AccountController.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
 using Pixel.Identity.Core;
 using Pixel.Identity.Core.Controllers;
+using Pixel.Identity.Store.Mongo.Models;
 
 namespace Pixel.Identity.Store.Mongo.Controllers
 {
-    public class AccountController : AccountController<ApplicationUser>
+    public class AccountController : AccountController<ApplicationUser, ObjectId>
     {
         public AccountController(UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager, IEmailSender emailSender) 

--- a/src/Pixel.Identity.Store.Mongo/Controllers/AuthenticatorController.cs
+++ b/src/Pixel.Identity.Store.Mongo/Controllers/AuthenticatorController.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
 using Pixel.Identity.Core.Controllers;
+using Pixel.Identity.Store.Mongo.Models;
 using System.Text.Encodings.Web;
 
 namespace Pixel.Identity.Store.Mongo.Controllers
@@ -9,7 +11,7 @@ namespace Pixel.Identity.Store.Mongo.Controllers
     [Authorize]
     [ApiController]
     [Route("api/[controller]")]
-    public class AuthenticatorController : AuthenticatorController<ApplicationUser>
+    public class AuthenticatorController : AuthenticatorController<ApplicationUser, ObjectId>
     {
         public AuthenticatorController(UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager, UrlEncoder urlEncoder)

--- a/src/Pixel.Identity.Store.Mongo/Controllers/AuthorizationController.cs
+++ b/src/Pixel.Identity.Store.Mongo/Controllers/AuthorizationController.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
 using OpenIddict.Abstractions;
 using Pixel.Identity.Core.Controllers;
-using Pixel.Identity.Store.Mongo;
+using Pixel.Identity.Store.Mongo.Models;
 
 namespace Pixel.Identity.Store.Mongo.Controllers
 {
@@ -9,7 +10,7 @@ namespace Pixel.Identity.Store.Mongo.Controllers
     /// Controller for handling OpenId protocol using OpenIdDict.
     /// It provides end points for authentication, tokens, sign out , etc.
     /// </summary>
-    public class AuthorizationController : AuthorizationController<ApplicationUser>
+    public class AuthorizationController : AuthorizationController<ApplicationUser, ObjectId>
     {
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.Mongo/Controllers/ExternalLoginsController.cs
+++ b/src/Pixel.Identity.Store.Mongo/Controllers/ExternalLoginsController.cs
@@ -1,13 +1,15 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
 using Pixel.Identity.Core.Controllers;
+using Pixel.Identity.Store.Mongo.Models;
 
 namespace Pixel.Identity.Store.Mongo.Controllers
 {
-    public class ExternalLoginsController : ExternalLoginsController<ApplicationUser>
+    public class ExternalLoginsController : ExternalLoginsController<ApplicationUser, ObjectId>
     {
         public ExternalLoginsController(UserManager<ApplicationUser> userManager, 
             SignInManager<ApplicationUser> signInManager, IUserStore<ApplicationUser> userStore,
-            ILogger<ExternalLoginsController<ApplicationUser>> logger) 
+            ILogger<ExternalLoginsController<ApplicationUser, ObjectId>> logger) 
             : base(userManager, signInManager, userStore, logger)
         {
         }

--- a/src/Pixel.Identity.Store.Mongo/Controllers/RolesController.cs
+++ b/src/Pixel.Identity.Store.Mongo/Controllers/RolesController.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
 using Pixel.Identity.Core.Controllers;
 using Pixel.Identity.Shared;
+using Pixel.Identity.Store.Mongo.Models;
 
 namespace Pixel.Identity.Store.Mongo.Controllers
 {
@@ -12,7 +14,7 @@ namespace Pixel.Identity.Store.Mongo.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [Authorize(Policy = Policies.CanManageRoles)]
-    public class RolesController : RolesController<ApplicationUser, ApplicationRole>
+    public class RolesController : RolesController<ApplicationUser, ApplicationRole, ObjectId>
     {
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.Mongo/Controllers/UserController.cs
+++ b/src/Pixel.Identity.Store.Mongo/Controllers/UserController.cs
@@ -2,8 +2,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
 using Pixel.Identity.Core.Controllers;
 using Pixel.Identity.Shared;
+using Pixel.Identity.Store.Mongo.Models;
 
 namespace Pixel.Identity.Store.Mongo.Controllers
 {
@@ -13,7 +15,7 @@ namespace Pixel.Identity.Store.Mongo.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [Authorize]
-    public class UsersController : UsersController<ApplicationUser>
+    public class UsersController : UsersController<ApplicationUser, ObjectId>
     {
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.Mongo/Controllers/UserInfoController.cs
+++ b/src/Pixel.Identity.Store.Mongo/Controllers/UserInfoController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using MongoDB.Bson;
 using Pixel.Identity.Core.Controllers;
+using Pixel.Identity.Store.Mongo.Models;
 
 namespace Pixel.Identity.Store.Mongo.Controllers
 {
@@ -9,7 +11,7 @@ namespace Pixel.Identity.Store.Mongo.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    public class UserInfoController : UserinfoController<ApplicationUser>
+    public class UserInfoController : UserinfoController<ApplicationUser, ObjectId>
     {
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.Mongo/Extensions/IdentityBuilderExtensions.cs
+++ b/src/Pixel.Identity.Store.Mongo/Extensions/IdentityBuilderExtensions.cs
@@ -1,0 +1,47 @@
+﻿using Dawn;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Pixel.Identity.Store.Mongo.Models;
+using Pixel.Identity.Store.Mongo.Stores;
+using Pixel.Identity.Store.Mongo.Utils;
+using System.ComponentModel;
+
+namespace Pixel.Identity.Store.Mongo.Extensions
+{
+    public static class IdentityBuilderExtensions
+    {
+        public static IdentityBuilder AddMongoDbStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>(this IdentityBuilder builder, MongoDbSettings dbSettings)
+              where TUser : ApplicationUser<TKey, TUserClaim, TUserLogin, TUserToken>, new ()
+              where TRole : ApplicationRole<TKey>, new ()
+              where TUserClaim : IdentityUserClaim<TKey>, new()
+              where TRoleClaim : IdentityRoleClaim<TKey>, new()
+              where TUserLogin : IdentityUserLogin<TKey>, new()
+              where TUserToken : IdentityUserToken<TKey>, new()
+              where TKey : IEquatable<TKey>
+        {
+            Guard.Argument(dbSettings).NotNull();
+            Guard.Argument(dbSettings.DatabaseName).NotNull().NotEmpty();
+            Guard.Argument(dbSettings.ConnectionString).NotNull().NotEmpty();
+
+            var mongoClient = new MongoClient(dbSettings.ConnectionString);
+            var mongoDb = mongoClient.GetDatabase(dbSettings.DatabaseName);
+            var usersCollection = mongoDb.GetCollection<TUser>(dbSettings.UsersCollection);
+            var rolesCollection = mongoDb.GetCollection<TRole>(dbSettings.RolesCollection);
+            var identityErrorDescriber = new IdentityErrorDescriber();
+
+            builder.Services.TryAddScoped<IUserStore<TUser>>(provider =>
+            {
+                return new UserStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>(usersCollection, rolesCollection, identityErrorDescriber);
+            });
+
+            builder.Services.TryAddScoped<IRoleStore<TRole>>(provider =>
+            {
+                return new RoleStore<TRole, TRoleClaim, TKey>(rolesCollection, identityErrorDescriber);
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/Pixel.Identity.Store.Mongo/Extensions/MongoCollectionExtensions.cs
+++ b/src/Pixel.Identity.Store.Mongo/Extensions/MongoCollectionExtensions.cs
@@ -1,0 +1,34 @@
+﻿using MongoDB.Driver;
+using Pixel.Identity.Store.Mongo.Contracts;
+using Pixel.Identity.Store.Mongo.Utils;
+using System.Linq.Expressions;
+
+namespace Pixel.Identity.Store.Mongo.Extensions
+{
+    public static class MongoCollectionExtensions
+    {
+        public static async Task<bool> UpdateField<TDocument, TKey, TField>(this IMongoCollection<TDocument> collection,
+            TDocument document,
+            Expression<Func<TDocument, TField>> field, TField value)  
+            where TKey : IEquatable<TKey>
+            where TDocument : IDocument<TKey>
+        {
+            var filterBuilder = Builders<TDocument>.Filter;
+            var filter = filterBuilder.Eq(t => t.Id, document.Id);
+            var updateBuilder = Builders<TDocument>.Update;
+            var update = updateBuilder.Set(field, value);
+            var result = await collection.UpdateOneAsync(filter, update);
+            return result.IsAcknowledged && result.ModifiedCount == 1;
+        }
+
+        public static async Task<TItem> FindFirstOrDefaultAsync<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, bool>> p, CancellationToken cancellationToken = default)
+        {
+            return await (await collection.FindAsync(p, FindOptionsFactory.LimitTo<TItem>(1), cancellationToken).ConfigureAwait(false)).FirstOrDefaultAsync().ConfigureAwait(false);
+        }
+
+        public static async Task<IEnumerable<TItem>> WhereAsync<TItem>(this IMongoCollection<TItem> collection, Expression<Func<TItem, bool>> p, CancellationToken cancellationToken = default)
+        {          
+            return (await collection.FindAsync(p, cancellationToken: cancellationToken).ConfigureAwait(false)).ToEnumerable();
+        }
+    }
+}

--- a/src/Pixel.Identity.Store.Mongo/Models/ApplicationRole.cs
+++ b/src/Pixel.Identity.Store.Mongo/Models/ApplicationRole.cs
@@ -1,12 +1,27 @@
-﻿using AspNetCore.Identity.MongoDbCore.Models;
+﻿using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
+using Pixel.Identity.Store.Mongo.Contracts;
+using System.Security.Claims;
 
-namespace Pixel.Identity.Store.Mongo
+namespace Pixel.Identity.Store.Mongo.Models
 {
     /// <summary>
-    /// ApplicationRole is the <see cref="IdentityRole"/> with Guid as primary key required by Asp.Net Identity
+    /// ApplicationRole with <see cref="ObjectId"/> as the Identifier type
     /// </summary>
-    public class ApplicationRole : MongoIdentityRole<Guid>
+    public class ApplicationRole : ApplicationRole<ObjectId>
     {
+
+    }
+
+    /// <summary>
+    /// ApplicationRole extends <see cref="IdentityRole{TKey}"/>
+    /// </summary>
+    public class ApplicationRole<TKey> : IdentityRole<TKey>, IDocument<TKey> where TKey : IEquatable<TKey>
+    {
+        public int Version { get; set; } = 1;
+
+        public List<IdentityRoleClaim<TKey>> Claims { get; set; } = new();
+
         /// <summary>
         /// constructor
         /// </summary>
@@ -22,6 +37,16 @@ namespace Pixel.Identity.Store.Mongo
         public ApplicationRole(string roleName) : base(roleName)
         {
 
+        }
+
+        /// <summary>
+        /// Check if role has specified <see cref="Claim"/>
+        /// </summary>
+        /// <param name="claim"></param>
+        /// <returns>True if Claim exists on Role</returns>
+        public virtual bool HasClaim(Claim claim)
+        {
+            return this.Claims.Any(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
         }
     }
 }

--- a/src/Pixel.Identity.Store.Mongo/Models/ApplicationUser.cs
+++ b/src/Pixel.Identity.Store.Mongo/Models/ApplicationUser.cs
@@ -1,12 +1,54 @@
-﻿using AspNetCore.Identity.MongoDbCore.Models;
+﻿using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
+using Pixel.Identity.Store.Mongo.Contracts;
+using System.Security.Claims;
 
-namespace Pixel.Identity.Store.Mongo
+namespace Pixel.Identity.Store.Mongo.Models
 {
     /// <summary>
-    /// ApplicationUser is the <see cref="IdentityUser"/> with Guid as primary key required by Asp.Net Identity
+    /// ApplicationUser with <see cref="ObjectId"/> as the Identifier type
     /// </summary>
-    public class ApplicationUser : MongoIdentityUser<Guid>
+    public class ApplicationUser : ApplicationUser<ObjectId, IdentityUserClaim, 
+        IdentityUserLogin<ObjectId>, IdentityUserToken<ObjectId>>
     {
+       
+    }
+
+    /// <summary>
+    /// ApplicationUser extends <see cref="IdentityUser{TKey}"/>
+    /// </summary>
+    public class ApplicationUser<TKey, TUserClaim, TUserLogin, TUserToken> 
+        : IdentityUser<TKey> , IDocument<TKey>
+        where TKey : IEquatable<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>, new()
+        where TUserLogin : IdentityUserLogin<TKey>, new()
+        where TUserToken : IdentityUserToken<TKey>, new()
+    {
+        /// <summary>
+        /// version of the document
+        /// </summary>
+        public int Version { get; set; } = 1;
+
+        /// <summary>
+        /// Roles mapped to the user
+        /// </summary>
+        public List<TKey> Roles { get; set; } = new();
+
+        /// <summary>
+        /// Claims that belong to user
+        /// </summary>
+        public List<TUserClaim> Claims { get; set; } = new();
+
+        /// <summary>
+        /// External logins belonging to a user 
+        /// </summary>
+        public List<TUserLogin> Logins { get; set; } = new();
+
+        /// <summary>
+        /// Tokens belonging to user e.g. recovery codes and authenticator key
+        /// </summary>
+        public List<TUserToken> Tokens { get; set; } = new();
+
         /// <summary>
         /// constructor
         /// </summary>
@@ -20,8 +62,49 @@ namespace Pixel.Identity.Store.Mongo
         /// </summary>
         /// <param name="userName">name of the user</param>
         /// <param name="email">emaild of the user</param>
-        public ApplicationUser(string userName, string email) : base(userName, email)
+        public ApplicationUser(string userName, string email) : base(userName)
         {
+            this.Email = email;
+        }
+
+        /// <summary>
+        /// Check if role is mapped to user
+        /// </summary>
+        /// <param name="roleId"></param>
+        /// <returns>True if user belongs to specified role</returns>
+        public virtual bool HasRole(TKey roleId)
+        {
+            return this.Roles.Contains(roleId);
+        }
+
+        /// <summary>
+        /// Check if user has specified <see cref="Claim"/>
+        /// </summary>
+        /// <param name="claim"></param>
+        /// <returns>True if Claim belongs to user</returns>
+        public virtual bool HasClaim(Claim claim)
+        {
+            return this.Claims.Any(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
+        }
+
+        /// <summary>
+        /// Check if user has specified <see cref="UserLoginInfo"/>
+        /// </summary>
+        /// <param name="userLoginInfo"></param>
+        /// <returns>True if UserLoginInfo belongs to user</returns>
+        public virtual bool HasLogin(UserLoginInfo userLoginInfo)
+        {
+            return this.Logins.Any(e => e.LoginProvider == userLoginInfo.LoginProvider && e.ProviderKey == userLoginInfo.ProviderKey);
+        }
+
+        /// <summary>
+        /// Check if user has specified <see cref="IdentityUserToken{TKey}"/>
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns>True if Token exists for user</returns>
+        public virtual bool HasToken(TUserToken token)
+        {
+            return this.Tokens.Any(t => t.LoginProvider == token.LoginProvider && t.Name == token.Name && t.Value == token.Value);
         }
     }
 }

--- a/src/Pixel.Identity.Store.Mongo/Models/IdentityRoleClaim.cs
+++ b/src/Pixel.Identity.Store.Mongo/Models/IdentityRoleClaim.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
+
+namespace Pixel.Identity.Store.Mongo.Models
+{
+    /// <summary>
+    /// IdentityRoleClaim with <see cref="ObjectId"/> as the Identifier type
+    /// </summary>
+    public class IdentityRoleClaim : IdentityRoleClaim<ObjectId>
+    {       
+       
+    }
+}

--- a/src/Pixel.Identity.Store.Mongo/Models/IdentityUserClaim.cs
+++ b/src/Pixel.Identity.Store.Mongo/Models/IdentityUserClaim.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
+
+namespace Pixel.Identity.Store.Mongo.Models
+{
+    /// <summary>
+    /// IdentityUserClaim with <see cref="ObjectId"/> as the Identifier type
+    /// </summary>
+    public class IdentityUserClaim : IdentityUserClaim<ObjectId>
+    {
+    }
+}

--- a/src/Pixel.Identity.Store.Mongo/Models/MongoDbSettings.cs
+++ b/src/Pixel.Identity.Store.Mongo/Models/MongoDbSettings.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace Pixel.Identity.Store.Mongo.Models
+{
+    public class MongoDbSettings
+    {
+        /// <summary>
+        /// Connection string for the the MongoDb
+        /// </summary>
+        public string ConnectionString { get; set; } = "mongodb://localhost:27017";
+
+        /// <summary>
+        /// Name of the Database
+        /// </summary>
+        public string DatabaseName { get; set; } = "pixel-identity-db";
+
+        /// <summary>
+        /// Collection used to store <see cref="IdentityUser{TKey}"/>
+        /// </summary>
+        public string UsersCollection { get; set; } = "applicationUsers";
+
+        /// <summary>
+        /// Collection used to store <see cref="IdentityRole{TKey}"/>
+        /// </summary>
+        public string RolesCollection { get; set; } = "applicationRoles";
+    }
+}

--- a/src/Pixel.Identity.Store.Mongo/MongoConfigurator.cs
+++ b/src/Pixel.Identity.Store.Mongo/MongoConfigurator.cs
@@ -1,9 +1,13 @@
-﻿using AspNetCore.Identity.MongoDbCore.Infrastructure;
-using AutoMapper;
+﻿using AutoMapper;
 using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Pixel.Identity.Core;
 using Pixel.Identity.Core.Conventions;
+using Pixel.Identity.Store.Mongo.Extensions;
+using Pixel.Identity.Store.Mongo.Models;
+using Pixel.Identity.Store.Mongo.Utils;
+using System.ComponentModel;
 
 namespace Pixel.Identity.Store.Mongo
 {
@@ -41,7 +45,8 @@ namespace Pixel.Identity.Store.Mongo
                 //options.User.RequireUniqueEmail = true;               
             })
             .AddRoles<ApplicationRole>()
-            .AddMongoDbStores<ApplicationUser, ApplicationRole, Guid>(mongoDbSettings.ConnectionString, mongoDbSettings.DatabaseName);
+            .AddMongoDbStore<ApplicationUser, ApplicationRole, 
+                IdentityUserClaim, IdentityUserLogin<ObjectId>, IdentityUserToken<ObjectId>, IdentityRoleClaim, ObjectId>(mongoDbSettings);
         }
 
         ///<inheritdoc/>
@@ -62,12 +67,12 @@ namespace Pixel.Identity.Store.Mongo
 
         ///<inheritdoc/>
         public void AddServices(IServiceCollection services)
-        {
+        {        
             services.AddControllersWithViews()
                  .AddApplicationPart(typeof(ApplicationUser).Assembly)
                  .AddRazorPagesOptions(options =>
                  {
-                     options.Conventions.Add(new IdentityPageModelConvention<ApplicationUser>());
+                     options.Conventions.Add(new IdentityPageModelConvention<ApplicationUser, ObjectId>());
                  });            
             services.AddHostedService<Worker>();
         }

--- a/src/Pixel.Identity.Store.Mongo/Pixel.Identity.Store.Mongo.csproj
+++ b/src/Pixel.Identity.Store.Mongo/Pixel.Identity.Store.Mongo.csproj
@@ -7,11 +7,11 @@
 	<EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="AspNetCore.Identity.MongoDbCore" Version="3.1.2" />
+	<ItemGroup>		
 		<PackageReference Include="AutoMapper" Version="10.1.1">
 			<ExcludeAssets>runtime</ExcludeAssets>
-		</PackageReference>	
+		</PackageReference>		
+		<PackageReference Include="Dawn.Guard" Version="1.12.0" />	
 		<PackageReference Include="MongoDB.Driver" Version="2.14.1" />
 		<PackageReference Include="OpenIddict.Abstractions" Version="3.1.1">
 			<ExcludeAssets>runtime</ExcludeAssets>

--- a/src/Pixel.Identity.Store.Mongo/Stores/RoleStore.cs
+++ b/src/Pixel.Identity.Store.Mongo/Stores/RoleStore.cs
@@ -1,0 +1,252 @@
+﻿using Dawn;
+using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Pixel.Identity.Store.Mongo.Extensions;
+using Pixel.Identity.Store.Mongo.Models;
+using System.ComponentModel;
+using System.Security.Claims;
+
+namespace Pixel.Identity.Store.Mongo.Stores
+{
+    /// <summary>
+    /// Implementation of <see cref="IRoleClaimStore{TRole}"/> used to manage Identity roles and associated claims
+    /// </summary>
+    /// <typeparam name="TRole">Type representing a <see cref="IdentityRole{TKey}"/></typeparam>
+    /// <typeparam name="TRoleClaim">Type representing a <see cref="IdentityRoleClaim{TKey}"/></typeparam>
+    /// <typeparam name="TKey">Identifier type for documents e.g. Guid or ObjectId</typeparam>
+    public class RoleStore<TRole, TRoleClaim, TKey> : IQueryableRoleStore<TRole>, IRoleClaimStore<TRole>
+        where TRole : ApplicationRole<TKey>       
+        where TRoleClaim : IdentityRoleClaim<TKey>, new()
+       where TKey : IEquatable<TKey>
+    {
+        private bool disposed;       
+        private readonly IMongoCollection<TRole> rolesCollection;
+
+        /// <summary>
+        /// Gets or sets the <see cref="IdentityErrorDescriber"/> for any error that occurred with the current operation.
+        /// </summary>
+        public IdentityErrorDescriber ErrorDescriber { get; set; }
+
+        /// <inheritdoc/>       
+        public IQueryable<TRole> Roles => rolesCollection.AsQueryable();
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="rolesCollection"></param>
+        /// <param name="describer"></param>
+        public RoleStore(IMongoCollection<TRole> rolesCollection, IdentityErrorDescriber describer)
+        {
+            this.rolesCollection = rolesCollection;
+            this.ErrorDescriber = describer ?? new IdentityErrorDescriber();
+        }  
+
+        /// <inheritdoc/>  
+        public Task<TRole> FindByIdAsync(string roleId, CancellationToken cancellationToken)
+        {
+            Guard.Argument(roleId).NotNull().NotEmpty();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return rolesCollection.FindFirstOrDefaultAsync(x => x.Id.Equals(ConvertIdFromString(roleId)), cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc/>  
+        public Task<TRole> FindByNameAsync(string normalizedRoleName, CancellationToken cancellationToken)
+        {
+            Guard.Argument(normalizedRoleName).NotNull().NotEmpty();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return rolesCollection.FindFirstOrDefaultAsync(x => x.NormalizedName == normalizedRoleName, cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc/>  
+        public async Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            await rolesCollection.InsertOneAsync(role, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return IdentityResult.Success;
+        }
+
+        /// <inheritdoc/>  
+        public async Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var currentConcurrencyStamp = role.ConcurrencyStamp;
+            role.ConcurrencyStamp = Guid.NewGuid().ToString();
+            
+            var result = await rolesCollection.ReplaceOneAsync(x => x.Id.Equals(role.Id) && x.ConcurrencyStamp.Equals(currentConcurrencyStamp), role, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!result.IsAcknowledged || result.ModifiedCount == 0)
+            {
+                return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
+            }
+            return IdentityResult.Success;          
+        }
+
+        /// <inheritdoc/>  
+        public async Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var result = await rolesCollection.DeleteOneAsync(x => x.Id.Equals(role.Id) && x.ConcurrencyStamp.Equals(role.ConcurrencyStamp), cancellationToken).ConfigureAwait(false);
+            if (!result.IsAcknowledged || result.DeletedCount == 0)
+            {
+                return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
+            }
+
+            return IdentityResult.Success;
+        }
+
+        /// <inheritdoc/>  
+        public Task<string> GetRoleIdAsync(TRole role, CancellationToken cancellationToken)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return Task.FromResult(ConvertIdToString(role.Id));
+        }
+
+        /// <inheritdoc/>  
+        public Task<string> GetRoleNameAsync(TRole role, CancellationToken cancellationToken)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return Task.FromResult(role.Name);
+        }
+
+        /// <inheritdoc/>  
+        public Task<string> GetNormalizedRoleNameAsync(TRole role, CancellationToken cancellationToken)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return Task.FromResult(role.NormalizedName);
+        }
+
+        /// <inheritdoc/>  
+        public async Task SetNormalizedRoleNameAsync(TRole role, string normalizedName, CancellationToken cancellationToken)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (role.NormalizedName != normalizedName)
+            {
+                role.NormalizedName = normalizedName;
+                await rolesCollection.UpdateField<TRole, TKey, string>(role, e => e.NormalizedName, role.NormalizedName);
+            }
+        }
+
+        /// <inheritdoc/>  
+        public async Task SetRoleNameAsync(TRole role, string roleName, CancellationToken cancellationToken)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (role.Name != roleName)
+            {
+                role.Name = roleName;
+                await rolesCollection.UpdateField<TRole, TKey, string>(role, e => e.Name, role.Name);
+            }
+        }
+
+        /// <inheritdoc/>  
+        public async Task AddClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(role).NotNull();
+            Guard.Argument(claim).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if(!role.HasClaim(claim))
+            {
+                var identityRoleClaim = CreateRoleClaim(role, claim);
+                role.Claims.Add(identityRoleClaim);
+                await rolesCollection.UpdateOneAsync(x => x.Id.Equals(role.Id), Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken).ConfigureAwait(false);              
+            }
+            
+        }
+
+        /// <inheritdoc/>  
+        public async Task RemoveClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(role).NotNull();
+            Guard.Argument(claim).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if(role.HasClaim(claim))
+            {
+                role.Claims.RemoveAll(x => x.ClaimType == claim.Type && x.ClaimValue == claim.Value);
+                await rolesCollection.UpdateOneAsync(x => x.Id.Equals(role.Id), Builders<TRole>.Update.Set(x => x.Claims, role.Claims), cancellationToken: cancellationToken);             
+            }
+            
+        }
+
+        /// <inheritdoc/>  
+        public async Task<IList<Claim>> GetClaimsAsync(TRole role, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(role).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var dbRole = await rolesCollection.FindFirstOrDefaultAsync(x => x.Id.Equals(role.Id), cancellationToken: cancellationToken).ConfigureAwait(false);
+            return dbRole?.Claims.Select(e => e.ToClaim()).ToList() ?? Enumerable.Empty<Claim>().ToList();
+        }
+
+        /// <summary>
+        /// Creates an entity representing a role claim.
+        /// </summary>
+        /// <param name="role">The associated role.</param>
+        /// <param name="claim">The associated claim.</param>
+        /// <returns>The role claim entity.</returns>
+        protected virtual TRoleClaim CreateRoleClaim(TRole role, Claim claim)
+        {
+            var roleClaim = new TRoleClaim();
+            roleClaim.InitializeFromClaim(claim);
+            return roleClaim;
+        }
+
+        #region helper methods
+
+        /// <inheritdoc/>  
+        public virtual TKey ConvertIdFromString(string id)
+        {
+            if (id == null)
+            {
+                return default(TKey);
+            }
+
+            if (typeof(TKey) == typeof(ObjectId))
+            {
+                return (TKey)((object)ObjectId.Parse(id));
+            }
+
+            return (TKey)TypeDescriptor.GetConverter(typeof(TKey)).ConvertFromInvariantString(id);
+        }
+
+        /// <inheritdoc/>  
+        public virtual string ConvertIdToString(TKey id)
+        {
+            if (id.Equals(default(TKey)))
+            {
+                return null;
+            }
+            return id.ToString();
+        }
+
+
+        /// <summary>
+        /// Throws if this class has been disposed or cancellation requested on CancellationToken .
+        /// </summary>
+        protected void ThrowIfDisposedOrCancelled(CancellationToken cancellationToken)
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>
+        /// Dispose the stores
+        /// </summary>
+        public void Dispose() => disposed = true;
+
+        #endregion helper methods
+
+    }
+}

--- a/src/Pixel.Identity.Store.Mongo/Stores/UsersStore.cs
+++ b/src/Pixel.Identity.Store.Mongo/Stores/UsersStore.cs
@@ -1,0 +1,736 @@
+﻿using Dawn;
+using Microsoft.AspNetCore.Identity;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Pixel.Identity.Store.Mongo.Extensions;
+using Pixel.Identity.Store.Mongo.Models;
+using System.ComponentModel;
+using System.Security.Claims;
+
+namespace Pixel.Identity.Store.Mongo.Stores
+{
+    /// <summary>
+    /// UserStore is used to manage <see cref="IdentityUser{TKey}"/> which includes roles, claims, logins, tokens , etc.
+    /// </summary>
+    /// <typeparam name="TUser">Type representing a <see cref="IdentityUser{TKey}"/></typeparam>
+    /// <typeparam name="TRole">Type representing a <see cref="IdentityRole{TKey}"/></typeparam>
+    /// <typeparam name="TUserClaim">Type representing a <see cref="IdentityUserClaim{TKey}{TKey}"/></typeparam>
+    /// <typeparam name="TUserLogin">Type representing a <see cref="IdentityUserLogin{TKey}"/></typeparam>
+    /// <typeparam name="TUserToken">Type representing a <see cref="IdentityUserToken{TKey}"/></typeparam>
+    /// <typeparam name="TRoleClaim">Type representing a <see cref="IdentityRoleClaim{TKey}"/></typeparam>
+    /// <typeparam name="TKey">Identifier type for documents e.g. Guid or ObjectId</typeparam>
+    public class UserStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>
+       : UserStoreBase<TUser, TRole, TKey, TUserClaim, TUserLogin, TUserToken,TRoleClaim>
+       where TUser : ApplicationUser<TKey, TUserClaim, TUserLogin, TUserToken>
+       where TRole : ApplicationRole<TKey>
+       where TUserClaim : IdentityUserClaim<TKey>, new()
+       where TUserLogin : IdentityUserLogin<TKey>, new()
+       where TUserToken : IdentityUserToken<TKey>, new()
+       where TRoleClaim : IdentityRoleClaim<TKey>, new()
+       where TKey : IEquatable<TKey>
+    {
+        private static readonly InsertOneOptions InsertOneOptions = new InsertOneOptions();
+        private static readonly FindOptions<TUser> FindOptions = new FindOptions<TUser>();
+        private static readonly ReplaceOptions ReplaceOptions = new ReplaceOptions();
+
+
+        private readonly IMongoCollection<TUser> usersCollection;
+        private readonly IMongoCollection<TRole> rolesCollection;
+
+        /// <inheritdoc/>  
+        public override IQueryable<TUser> Users => usersCollection.AsQueryable();
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="rolesCollection"></param>
+        /// <param name="describer"></param>
+        public UserStore(IMongoCollection<TUser> usersCollection, IMongoCollection<TRole> rolesCollection, IdentityErrorDescriber describer)
+            : base(describer)
+        {
+            this.usersCollection = usersCollection;
+            this.rolesCollection = rolesCollection;
+        }
+
+        #region IUserClaimStore
+
+        /// <inheritdoc/>  
+        public override Task<IList<Claim>> GetClaimsAsync(TUser user, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);         
+            return Task.FromResult<IList<Claim>>(user.Claims.Select(x => x.ToClaim()).ToList());
+        }
+
+        /// <inheritdoc/>
+        public override async Task AddClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            Guard.Argument(claims).NotNull().NotEmpty();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            foreach (var claim in claims)
+            {
+                if(!user.HasClaim(claim))
+                {
+                    user.Claims.Add(CreateUserClaim(user, claim));
+                    await usersCollection.UpdateField<TUser, TKey, List<TUserClaim>>(user, u => u.Claims, user.Claims);                  
+                }
+            }            
+        }
+
+        /// <inheritdoc/>
+        public override async Task ReplaceClaimAsync(TUser user, Claim claim, Claim newClaim, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            Guard.Argument(claim).NotNull();
+            Guard.Argument(newClaim).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var matchedClaims = user.Claims.Where(uc => uc.ClaimValue == claim.Value && uc.ClaimType == claim.Type).ToList();           
+            if(matchedClaims.Any())
+            {
+                foreach (var matchedClaim in matchedClaims)
+                {
+                    matchedClaim.ClaimValue = newClaim.Value;
+                    matchedClaim.ClaimType = newClaim.Type;
+                }
+                await usersCollection.UpdateField<TUser, TKey, List<TUserClaim>>(user, u => u.Claims, user.Claims);
+            }         
+        }
+
+        /// <inheritdoc/>
+        public override async Task RemoveClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            Guard.Argument(claims).NotNull().NotEmpty();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            foreach (var claim in claims)
+            {
+                user.Claims.RemoveAll(x => x.ClaimType == claim.Type && x.ClaimValue == claim.Value);
+            }
+            await usersCollection.UpdateField<TUser, TKey, List<TUserClaim>>(user, u => u.Claims, user.Claims);
+        }
+
+        /// <inheritdoc/>
+        public override async Task<IList<TUser>> GetUsersForClaimAsync(Claim claim, CancellationToken cancellationToken)
+        {
+            Guard.Argument(claim).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return (await usersCollection.WhereAsync(u => u.Claims.Any(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value), cancellationToken).ConfigureAwait(false)).ToList();
+        }
+
+        #endregion IUserClaimStore
+
+        #region IUserLoginStore
+
+        /// <inheritdoc/>
+        public override Task<IList<UserLoginInfo>> GetLoginsAsync(TUser user, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);           
+            return Task.FromResult<IList<UserLoginInfo>>(user.Logins.Select(x => new UserLoginInfo(x.LoginProvider, x.ProviderKey, x.ProviderDisplayName)).ToList());
+        }
+
+        /// <inheritdoc/>
+        public override async Task AddLoginAsync(TUser user, UserLoginInfo login, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            Guard.Argument(login).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if(!user.HasLogin(login))
+            {
+                user.Logins.Add(CreateUserLogin(user, login));
+                await usersCollection.UpdateField<TUser, TKey, List<TUserLogin>>(user, u => u.Logins, user.Logins);
+            }           
+        }
+
+        /// <inheritdoc/>
+        public override async Task RemoveLoginAsync(TUser user, string loginProvider, string providerKey, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if(user.Logins.Any(x => x.LoginProvider == loginProvider && x.ProviderKey == providerKey))
+            {
+                user.Logins.RemoveAll(x => x.LoginProvider == loginProvider && x.ProviderKey == providerKey);
+                await usersCollection.UpdateField<TUser, TKey, List<TUserLogin>>(user, u => u.Logins, user.Logins);
+            }           
+        }
+
+        #endregion IUserLoginStore
+
+        #region IUserRoleStore
+
+        /// <inheritdoc/>
+        public override async Task<IList<TUser>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken)
+        {
+            Guard.Argument(roleName).NotNull().NotEmpty();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var role = await FindRoleAsync(roleName, cancellationToken);
+            if (role == null)
+            {
+                return new List<TUser>();
+            }
+            var filter = Builders<TUser>.Filter.AnyEq(x => x.Roles, role.Id);
+            return (await usersCollection.FindAsync(filter, FindOptions, cancellationToken).ConfigureAwait(true)).ToList();
+        }
+
+        /// <inheritdoc/>  
+        public override async Task<IList<string>> GetRolesAsync(TUser user, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var userDb = await FindByIdAsync(ConvertIdToString(user.Id), cancellationToken).ConfigureAwait(true);
+            if (userDb == null)
+            {
+                return new List<string>();
+            }
+
+            var roles = new List<string>();
+            foreach (var item in userDb.Roles)
+            {
+                var dbRole = await rolesCollection.FindFirstOrDefaultAsync(r => r.Id.Equals(item), cancellationToken).ConfigureAwait(true);
+
+                if (dbRole != null)
+                {
+                    roles.Add(dbRole.Name);
+                }
+            }
+            return roles;
+        }
+
+        /// <inheritdoc/>  
+        public override async Task<bool> IsInRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var dbUser = await FindByIdAsync(ConvertIdToString(user.Id), cancellationToken).ConfigureAwait(true);
+            var role = await FindRoleAsync(roleName, cancellationToken).ConfigureAwait(true);
+            if (role == null)
+            {
+                return false;
+            }
+            return dbUser?.Roles.Contains(role.Id) ?? false;
+        }
+
+        /// <inheritdoc/>  
+        public override async Task AddToRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            Guard.Argument(roleName).NotNull().NotEmpty().NotWhiteSpace();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var roleEntity = await FindRoleAsync(roleName, cancellationToken)
+                ?? throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, "Role {0} does not exist.", roleName));
+            if(!user.HasRole(roleEntity.Id))
+            {
+                user.Roles.Add(roleEntity.Id);
+                await usersCollection.UpdateField<TUser, TKey, List<TKey>>(user, u => u.Roles, user.Roles);               
+            }           
+        }
+
+        /// <inheritdoc/>  
+        public override async Task RemoveFromRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            Guard.Argument(roleName).NotNull().NotEmpty().NotWhiteSpace();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var roleEntity = await FindRoleAsync(roleName, cancellationToken);
+            if (roleEntity != null)
+            {
+                if (user.HasRole(roleEntity.Id))
+                {
+                    user.Roles.Remove(roleEntity.Id);
+                    await usersCollection.UpdateField<TUser, TKey, List<TKey>>(user, u => u.Roles, user.Roles);
+                }
+                   
+            }
+        }
+
+        #endregion IUserRoleStore
+
+        #region IUserEmailStore
+
+        /// <inheritdoc/>  
+        public override Task<TUser> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return usersCollection.FindFirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail, cancellationToken);
+        }
+
+        /// <inheritdoc/>  
+        public override async Task SetEmailAsync(TUser user, string email, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.Email != email)
+            {
+                user.Email = email;
+                await usersCollection.UpdateField<TUser, TKey, string>(user, e => e.Email, user.Email);
+            }
+        }
+
+        /// <inheritdoc/>  
+        public override async Task SetNormalizedEmailAsync(TUser user, string normalizedEmail, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.NormalizedEmail != normalizedEmail)
+            {
+                user.NormalizedEmail = normalizedEmail;
+                await usersCollection.UpdateField<TUser, TKey, string>(user, e => e.NormalizedEmail, user.NormalizedEmail);
+            }
+        }
+
+        /// <inheritdoc/>  
+        public override async Task SetEmailConfirmedAsync(TUser user, bool confirmed, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.EmailConfirmed != confirmed)
+            {
+                user.EmailConfirmed = confirmed;
+                await usersCollection.UpdateField<TUser, TKey, bool>(user, e => e.EmailConfirmed, user.EmailConfirmed);
+            }
+        }
+
+        #endregion IUserEmailStore            
+
+        #region IUserPhoneNumberStore
+
+        /// <inheritdoc/>  
+        public override async Task SetPhoneNumberAsync(TUser user, string phoneNumber, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.PhoneNumber != phoneNumber)
+            {
+                user.PhoneNumber = phoneNumber;
+                await usersCollection.UpdateField<TUser, TKey, string>(user, e => e.PhoneNumber, user.PhoneNumber);
+            }
+        }
+
+        /// <inheritdoc/>  
+        public override async Task SetPhoneNumberConfirmedAsync(TUser user, bool confirmed, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.PhoneNumberConfirmed != confirmed)
+            {
+                user.PhoneNumberConfirmed = confirmed;
+                await usersCollection.UpdateField<TUser, TKey, bool>(user, e => e.PhoneNumberConfirmed, user.PhoneNumberConfirmed);
+            }
+        }
+
+        #endregion IUserPhoneNumberStore
+
+        #region IUserPasswordStore
+
+        /// <inheritdoc/>  
+        public override async Task SetPasswordHashAsync(TUser user, string passwordHash, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.UserName != passwordHash)
+            {
+                user.PasswordHash = passwordHash;
+                await usersCollection.UpdateField<TUser, TKey, string>(user, e => e.PasswordHash, user.PasswordHash);
+            }
+        }
+
+        #endregion IUserPasswordStore
+
+        #region IUserSecurityStampStore
+
+        /// <inheritdoc/>
+        public override async Task SetSecurityStampAsync(TUser user, string stamp, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.SecurityStamp != stamp)
+            {
+                user.SecurityStamp = stamp;
+                await usersCollection.UpdateField<TUser, TKey, string>(user, e => e.SecurityStamp, user.SecurityStamp);
+            }
+        }
+
+        #endregion IUserSecurityStampStore
+
+        #region IUserLockoutStore
+
+        /// <inheritdoc/>  
+        public override async Task SetLockoutEndDateAsync(TUser user, DateTimeOffset? lockoutEnd, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.LockoutEnd != lockoutEnd)
+            {
+                user.LockoutEnd = lockoutEnd;
+                await usersCollection.UpdateField<TUser, TKey, DateTimeOffset?>(user, e => e.LockoutEnd, user.LockoutEnd);
+            }
+        }
+
+        /// <inheritdoc/>  
+        public override async Task<int> IncrementAccessFailedCountAsync(TUser user, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            user.AccessFailedCount++;
+            await usersCollection.UpdateField<TUser, TKey, int>(user, e => e.AccessFailedCount, user.AccessFailedCount);
+            return user.AccessFailedCount;
+        }
+
+        /// <inheritdoc/>  
+        public override async Task ResetAccessFailedCountAsync(TUser user, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if(user.AccessFailedCount != 0)
+            {
+                user.AccessFailedCount = 0;
+                await usersCollection.UpdateField<TUser, TKey, int>(user, e => e.AccessFailedCount, user.AccessFailedCount);
+            }                   
+        }
+
+        /// <inheritdoc/>  
+        public override async Task SetLockoutEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.LockoutEnabled != enabled)
+            {
+                user.LockoutEnabled = enabled;
+                await usersCollection.UpdateField<TUser, TKey, bool>(user, e => e.LockoutEnabled, user.LockoutEnabled);
+            }
+        }
+
+        #endregion IUserLockoutStore
+
+        #region IUserTwoFactorStore
+
+        /// <inheritdoc/> 
+        public override async Task SetTwoFactorEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.TwoFactorEnabled != enabled)
+            {
+                user.TwoFactorEnabled = enabled;
+                await usersCollection.UpdateField<TUser, TKey, bool>(user, e => e.TwoFactorEnabled, user.TwoFactorEnabled);
+            }
+        }
+
+        #endregion IUserTwoFactorStore
+
+        #region IUserAuthenticationTokenStore
+
+        /// <inheritdoc/> 
+        public override async Task SetTokenAsync(TUser user, string loginProvider, string name, string value, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);         
+
+            var token = await FindTokenAsync(user, loginProvider, name, cancellationToken).ConfigureAwait(false);
+            if (token == null)
+            {
+                token = CreateUserToken(user, loginProvider, name, value);               
+                await AddUserTokenAsync(token).ConfigureAwait(false);    
+                user.Tokens.Add(token);
+            }
+            else
+            {
+                token.Value = value;
+                await usersCollection.UpdateField<TUser, TKey, List<TUserToken>>(user, u => u.Tokens, user.Tokens);
+            }
+        }
+
+        /// <inheritdoc/> 
+        public override async Task RemoveTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var entry = await FindTokenAsync(user, loginProvider, name, cancellationToken).ConfigureAwait(false);
+            if (entry != null)
+            {            
+                await RemoveUserTokenAsync(entry).ConfigureAwait(false);
+                user.Tokens.Remove(entry);
+            }
+        }
+
+        #endregion IUserAuthenticationTokenStore
+
+        #region  IUserStore
+
+        /// <inheritdoc/>  
+        public override Task<TUser> FindByIdAsync(string userId, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            var id = ConvertIdFromString(userId);
+            return usersCollection.FindFirstOrDefaultAsync(x => x.Id.Equals(id), cancellationToken);
+        }
+
+        /// <inheritdoc/>  
+        public override async Task SetUserNameAsync(TUser user, string userName, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.UserName != userName)
+            {
+                user.UserName = userName;
+                await usersCollection.UpdateField<TUser, TKey, string>(user, e => e.UserName, user.UserName);
+            }
+        }
+
+        /// <inheritdoc/>  
+        public override async Task SetNormalizedUserNameAsync(TUser user, string normalizedName, CancellationToken cancellationToken = default)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            if (user.NormalizedUserName != normalizedName)
+            {
+                user.NormalizedUserName = normalizedName;
+                await usersCollection.UpdateField<TUser, TKey, string>(user, e => e.NormalizedUserName, user.NormalizedUserName);
+            }
+        }
+
+
+        /// <inheritdoc/>  
+        public override Task<TUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return usersCollection.FindFirstOrDefaultAsync(x => x.NormalizedUserName == normalizedUserName, cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc/>  
+        public async override Task<IdentityResult> CreateAsync(TUser user, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            await usersCollection.InsertOneAsync(user, InsertOneOptions, cancellationToken).ConfigureAwait(false);
+            return IdentityResult.Success;
+        }
+
+        /// <inheritdoc/>  
+        public async override Task<IdentityResult> UpdateAsync(TUser user, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var currentConcurrencyStamp = user.ConcurrencyStamp;
+            user.ConcurrencyStamp = Guid.NewGuid().ToString();
+            var result = await usersCollection.ReplaceOneAsync(x => x.Id.Equals(user.Id) && x.ConcurrencyStamp.Equals(currentConcurrencyStamp), user, ReplaceOptions, cancellationToken).ConfigureAwait(false);
+            if (!result.IsAcknowledged || result.ModifiedCount == 0)
+            {
+                return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
+            }
+            return IdentityResult.Success;
+        }
+
+        /// <inheritdoc/>  
+        public async override Task<IdentityResult> DeleteAsync(TUser user, CancellationToken cancellationToken)
+        {
+            Guard.Argument(user).NotNull();
+            ThrowIfDisposedOrCancelled(cancellationToken);
+
+            var result = await usersCollection.DeleteOneAsync(x => x.Id.Equals(user.Id) && x.ConcurrencyStamp.Equals(user.ConcurrencyStamp), cancellationToken).ConfigureAwait(false);
+            if (!result.IsAcknowledged || result.DeletedCount == 0)
+            {
+                return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
+            }
+            return IdentityResult.Success;
+        }
+
+        #endregion IUserStore
+
+        #region protected overridden methods
+
+        /// <inheritdoc/>  
+        protected override async Task AddUserTokenAsync(TUserToken token)
+        {
+            var user = await FindUserAsync(token.UserId, cancellationToken: CancellationToken.None);
+            if(!user.HasToken(token))
+            {               
+                await usersCollection.UpdateField<TUser, TKey, List<TUserToken>>(user, u => u.Tokens, user.Tokens);
+            }                  
+        }
+
+        /// <inheritdoc/>  
+        protected override async Task RemoveUserTokenAsync(TUserToken token)
+        {
+            var user = await FindUserAsync(token.UserId, cancellationToken: CancellationToken.None);
+            var tokenToRemove = user.Tokens.FirstOrDefault(t => t.LoginProvider == token.LoginProvider &&
+                t.Name == token.Name);
+            if(tokenToRemove != null)
+            {              
+                await usersCollection.UpdateField<TUser, TKey, List<TUserToken>>(user, u => u.Tokens, user.Tokens);
+            }       
+        }
+
+        /// <inheritdoc/>  
+        protected override Task<TRole> FindRoleAsync(string normalizedRoleName, CancellationToken cancellationToken)
+        {
+            return rolesCollection.FindFirstOrDefaultAsync(x => x.NormalizedName == normalizedRoleName, cancellationToken);
+        }
+
+        /// <inheritdoc/>  
+        protected override Task<TUserToken> FindTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
+        {          
+            return Task.FromResult<TUserToken>(user.Tokens?.FirstOrDefault(x => x.LoginProvider == loginProvider && x.Name == name));
+        }
+
+        /// <inheritdoc/>  
+        protected override Task<TUser> FindUserAsync(TKey userId, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposedOrCancelled(cancellationToken);
+            return usersCollection.FindFirstOrDefaultAsync(x => x.Id.Equals(userId), cancellationToken);
+        }
+
+        /// <inheritdoc/>  
+        protected override async Task<TUserLogin> FindUserLoginAsync(TKey userId, string loginProvider, string providerKey, CancellationToken cancellationToken)
+        {
+            var dbUser = await FindUserAsync(userId, cancellationToken).ConfigureAwait(true);
+            return dbUser?.Logins?.FirstOrDefault(x => x.LoginProvider == loginProvider && x.ProviderKey == providerKey);
+        }
+
+        /// <inheritdoc/>  
+        protected override async Task<TUserLogin> FindUserLoginAsync(string loginProvider, string providerKey, CancellationToken cancellationToken)
+        {
+            var userWithLogin = await usersCollection.FindFirstOrDefaultAsync(u =>
+                u.Logins.Any(l => l.LoginProvider == loginProvider && l.ProviderKey == providerKey), cancellationToken).ConfigureAwait(true);
+            return userWithLogin?.Logins.FirstOrDefault(l => l.LoginProvider == loginProvider && l.ProviderKey == providerKey);
+        }
+
+        #endregion protected overridden methods
+
+        #region Helper methods       
+
+        /// <inheritdoc/>  
+        public override TKey ConvertIdFromString(string id)
+        {
+            if (id == null)
+            {
+                return default(TKey);
+            }
+
+            if (typeof(TKey) == typeof(ObjectId))
+            {
+                return (TKey)((object)ObjectId.Parse(id));
+            }
+
+            return (TKey)TypeDescriptor.GetConverter(typeof(TKey)).ConvertFromInvariantString(id);
+        }
+
+        /// <inheritdoc/>  
+        public override string ConvertIdToString(TKey id)
+        {
+            if (id.Equals(default(TKey)))
+            {
+                return null;
+            }
+            return id.ToString();
+        }
+
+        /// <summary>
+        /// Throws if this class has been disposed or cancellation requested on CancellationToken .
+        /// </summary>
+        protected void ThrowIfDisposedOrCancelled(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        #endregion Helper methods
+
+    }
+
+    /// <summary>
+    /// Represents a new instance of a persistence store for the specified user and role types.
+    /// </summary>
+    /// <typeparam name="TUser">The type representing a user.</typeparam>
+    /// <typeparam name="TRole">The type representing a role.</typeparam>
+    /// <typeparam name="TKey">The type of the primary key for a role.</typeparam>
+    /// <typeparam name="TUserClaim">The type representing a claim.</typeparam>   
+    /// <typeparam name="TUserLogin">The type representing a user external login.</typeparam>
+    /// <typeparam name="TUserToken">The type representing a user token.</typeparam>
+    /// <typeparam name="TRoleClaim">The type representing a role claim.</typeparam>
+    public abstract class UserStoreBase<TUser, TRole, TKey, TUserClaim, TUserLogin, TUserToken, TRoleClaim> :
+        UserStoreBase<TUser, TKey, TUserClaim, TUserLogin, TUserToken>,
+        IUserRoleStore<TUser>
+        where TUser : ApplicationUser<TKey, TUserClaim, TUserLogin, TUserToken>
+        where TRole : ApplicationRole<TKey>
+        where TKey : IEquatable<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>, new()        
+        where TUserLogin : IdentityUserLogin<TKey>, new()
+        where TUserToken : IdentityUserToken<TKey>, new()
+        where TRoleClaim : IdentityRoleClaim<TKey>, new()
+    {
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="describer">The <see cref="IdentityErrorDescriber"/> used to describe store errors.</param>
+        public UserStoreBase(IdentityErrorDescriber describer) : base(describer) { }
+
+        /// <summary>
+        /// Retrieves all users in the specified role.
+        /// </summary>
+        /// <param name="normalizedRoleName">The role whose users should be retrieved.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>
+        /// The <see cref="Task"/> contains a list of users, if any, that are in the specified role.
+        /// </returns>
+        public abstract Task<IList<TUser>> GetUsersInRoleAsync(string normalizedRoleName, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Adds the given <paramref name="normalizedRoleName"/> to the specified <paramref name="user"/>.
+        /// </summary>
+        /// <param name="user">The user to add the role to.</param>
+        /// <param name="normalizedRoleName">The role to add.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public abstract Task AddToRoleAsync(TUser user, string normalizedRoleName, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Removes the given <paramref name="normalizedRoleName"/> from the specified <paramref name="user"/>.
+        /// </summary>
+        /// <param name="user">The user to remove the role from.</param>
+        /// <param name="normalizedRoleName">The role to remove.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public abstract Task RemoveFromRoleAsync(TUser user, string normalizedRoleName, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Retrieves the roles the specified <paramref name="user"/> is a member of.
+        /// </summary>
+        /// <param name="user">The user whose roles should be retrieved.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that contains the roles the user is a member of.</returns>
+        public abstract Task<IList<string>> GetRolesAsync(TUser user, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns a flag indicating if the specified user is a member of the give <paramref name="normalizedRoleName"/>.
+        /// </summary>
+        /// <param name="user">The user whose role membership should be checked.</param>
+        /// <param name="normalizedRoleName">The role to check membership of</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>A <see cref="Task{TResult}"/> containing a flag indicating if the specified user is a member of the given group. If the
+        /// user is a member of the group the returned value with be true, otherwise it will be false.</returns>
+        public abstract Task<bool> IsInRoleAsync(TUser user, string normalizedRoleName, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Return a role with the normalized name if it exists.
+        /// </summary>
+        /// <param name="normalizedRoleName">The normalized role name.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
+        /// <returns>The role if it exists.</returns>
+        protected abstract Task<TRole?> FindRoleAsync(string normalizedRoleName, CancellationToken cancellationToken);
+       
+    }  
+
+}

--- a/src/Pixel.Identity.Store.Mongo/Utils/FindOptionsFactory.cs
+++ b/src/Pixel.Identity.Store.Mongo/Utils/FindOptionsFactory.cs
@@ -1,0 +1,15 @@
+﻿using MongoDB.Driver;
+
+namespace Pixel.Identity.Store.Mongo.Utils
+{
+    public static class FindOptionsFactory
+    {
+        public static FindOptions<TItem> LimitTo<TItem>(int limit)
+        {
+            return new FindOptions<TItem>()
+            {
+                Limit = limit,
+            };
+        }
+    }
+}

--- a/src/Pixel.Identity.Store.PostgreSQL/SqlConfigurator.cs
+++ b/src/Pixel.Identity.Store.PostgreSQL/SqlConfigurator.cs
@@ -76,7 +76,7 @@ namespace Pixel.Identity.Store.PostgreSQL
                   .AddApplicationPart(typeof(SqlConfigurator).Assembly)
                   .AddRazorPagesOptions(options =>
                   {
-                      options.Conventions.Add(new IdentityPageModelConvention<ApplicationUser>());
+                      options.Conventions.Add(new IdentityPageModelConvention<ApplicationUser, Guid>());
                   }); ;
             services.AddHostedService<Worker>();
         }

--- a/src/Pixel.Identity.Store.Sql.Shared/Controllers/AccountController.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Controllers/AccountController.cs
@@ -4,7 +4,7 @@ using Pixel.Identity.Core.Controllers;
 
 namespace Pixel.Identity.Store.Sql.Shared.Controllers
 {
-    public class AccountController : AccountController<ApplicationUser>
+    public class AccountController : AccountController<ApplicationUser, Guid>
     {
         public AccountController(UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager, IEmailSender emailSender)

--- a/src/Pixel.Identity.Store.Sql.Shared/Controllers/AuthenticatorController.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Controllers/AuthenticatorController.cs
@@ -9,7 +9,7 @@ namespace Pixel.Identity.Store.Sql.Shared.Controllers
     [Authorize]
     [ApiController]
     [Route("api/[controller]")]
-    public class AuthenticatorController : AuthenticatorController<ApplicationUser>
+    public class AuthenticatorController : AuthenticatorController<ApplicationUser, Guid>
     {
         public AuthenticatorController(UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager, UrlEncoder urlEncoder)

--- a/src/Pixel.Identity.Store.Sql.Shared/Controllers/AuthorizationController.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Controllers/AuthorizationController.cs
@@ -8,7 +8,7 @@ namespace Pixel.Identity.Store.Sql.Shared.Controllers
     /// Controller for handling OpenId protocol using OpenIdDict.
     /// It provides end points for authentication, tokens, sign out , etc.
     /// </summary>
-    public class AuthorizationController : AuthorizationController<ApplicationUser>
+    public class AuthorizationController : AuthorizationController<ApplicationUser, Guid>
     {
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.Sql.Shared/Controllers/ExternalLoginsController.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Controllers/ExternalLoginsController.cs
@@ -3,11 +3,11 @@ using Pixel.Identity.Core.Controllers;
 
 namespace Pixel.Identity.Store.Sql.Shared.Controllers
 {
-    public class ExternalLoginsController : ExternalLoginsController<ApplicationUser>
+    public class ExternalLoginsController : ExternalLoginsController<ApplicationUser, Guid>
     {
         public ExternalLoginsController(UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager, IUserStore<ApplicationUser> userStore,
-            ILogger<ExternalLoginsController<ApplicationUser>> logger)
+            ILogger<ExternalLoginsController<ApplicationUser, Guid>> logger)
             : base(userManager, signInManager, userStore, logger)
         {
         }

--- a/src/Pixel.Identity.Store.Sql.Shared/Controllers/RolesController.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Controllers/RolesController.cs
@@ -12,7 +12,7 @@ namespace Pixel.Identity.Store.Sql.Shared.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [Authorize(Policy = Policies.CanManageRoles)]
-    public class RolesController : RolesController<ApplicationUser, ApplicationRole>
+    public class RolesController : RolesController<ApplicationUser, ApplicationRole, Guid>
     {
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.Sql.Shared/Controllers/UserController.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Controllers/UserController.cs
@@ -12,7 +12,7 @@ namespace Pixel.Identity.Store.Sql.Shared.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [Authorize]
-    public class UsersController : UsersController<ApplicationUser>
+    public class UsersController : UsersController<ApplicationUser, Guid>
     {
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.Sql.Shared/Controllers/UserInfoController.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Controllers/UserInfoController.cs
@@ -9,7 +9,7 @@ namespace Pixel.Identity.Store.Sql.Shared.Controllers
     /// </summary>
     [Route("api/[controller]")]
     [ApiController]
-    public class UserInfoController : UserinfoController<ApplicationUser>
+    public class UserInfoController : UserinfoController<ApplicationUser, Guid>
     {
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.SqlServer/SqlConfigurator.cs
+++ b/src/Pixel.Identity.Store.SqlServer/SqlConfigurator.cs
@@ -76,7 +76,7 @@ namespace Pixel.Identity.Store.SqlServer
                 .AddApplicationPart(typeof(SqlConfigurator).Assembly)
                 .AddRazorPagesOptions(options =>
                 {
-                    options.Conventions.Add(new IdentityPageModelConvention<ApplicationUser>());
+                    options.Conventions.Add(new IdentityPageModelConvention<ApplicationUser, Guid>());
                 }); ;                
             services.AddHostedService<Worker>();
         }


### PR DESCRIPTION
1. Remove dependency on AspNetCore.Identity.MongoDbCore as extending the models need workaround unlike EntityFramework implementation provided by Asp.Net. As a result of this , keeping both database providers in parity breaks lots of abstraction.
2. Implemented a custom user store and role store for MongoDb which offers more flexibility for customisation at the cost of maintaining additional code.
3. Changed the identifier used for user and role documents in mongo to ObjectId to keep it consistent with OpenIdDict documents for application, scopes, tokens and authorizations. 