### PR TITLE
Default admin account has emailconfirmed set to false.

### DIFF
--- a/src/Pixel.Identity.Store.Mongo/Worker.cs
+++ b/src/Pixel.Identity.Store.Mongo/Worker.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using OpenIddict.Abstractions;
+using Pixel.Identity.Store.Mongo.Models;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace Pixel.Identity.Store.Mongo
@@ -86,10 +87,11 @@ namespace Pixel.Identity.Store.Mongo
                 var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
                 if (userManager.Users.Count() == 0)
                 {
-                    var adminUser = new ApplicationUser() { EmailConfirmed = true };
+                    var adminUser = new ApplicationUser();
                     await userManager.SetUserNameAsync(adminUser, "admin@pixel.com");
                     await userManager.SetEmailAsync(adminUser, "admin@pixel.com");
                     await userManager.CreateAsync(adminUser, "Admi9@pixel");
+                    await userManager.ConfirmEmailAsync(adminUser, await userManager.GenerateEmailConfirmationTokenAsync(adminUser));
 
                     //assign IdentityAdmin role to user
                     await userManager.AddToRoleAsync(adminUser, "IdentityAdmin");

--- a/src/Pixel.Identity.Store.PostgreSQL/Worker.cs
+++ b/src/Pixel.Identity.Store.PostgreSQL/Worker.cs
@@ -92,10 +92,11 @@ namespace Pixel.Identity.Store.PostgreSQL
             var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
             if(userManager.Users.Count() == 0)
             {
-                var adminUser = new ApplicationUser() { EmailConfirmed = true };
+                var adminUser = new ApplicationUser();
                 await userManager.SetUserNameAsync(adminUser, "admin@pixel.com");
                 await userManager.SetEmailAsync(adminUser, "admin@pixel.com");
                 await userManager.CreateAsync(adminUser, "Admi9@pixel");
+                await userManager.ConfirmEmailAsync(adminUser, await userManager.GenerateEmailConfirmationTokenAsync(adminUser));
 
                 //assign IdentityAdmin role to user
                 await userManager.AddToRoleAsync(adminUser, "IdentityAdmin");

--- a/src/Pixel.Identity.Store.SqlServer/Worker.cs
+++ b/src/Pixel.Identity.Store.SqlServer/Worker.cs
@@ -92,11 +92,11 @@ namespace Pixel.Identity.Store.SqlServer
             var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
             if(userManager.Users.Count() == 0)
             {
-                var adminUser = new ApplicationUser() { EmailConfirmed = true };
+                var adminUser = new ApplicationUser();
                 await userManager.SetUserNameAsync(adminUser, "admin@pixel.com");
                 await userManager.SetEmailAsync(adminUser, "admin@pixel.com");
                 await userManager.CreateAsync(adminUser, "Admi9@pixel");
-
+                await userManager.ConfirmEmailAsync(adminUser, await userManager.GenerateEmailConfirmationTokenAsync(adminUser));
                 //assign IdentityAdmin role to user
                 await userManager.AddToRoleAsync(adminUser, "IdentityAdmin");
             }           


### PR DESCRIPTION
Default admin account created by workers have EmailConfirmed set to false. This prevents login using admin account.
Fixed issue with worker code to set EmailConfirmed to true for admin account while creating it.