### PR TITLE
Add missing page for Lockout endpoint

### DIFF
--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Lockout.cshtml
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Lockout.cshtml
@@ -1,0 +1,10 @@
+﻿@page
+@model LockoutModel
+@{
+    ViewData["Title"] = "Locked out";
+}
+
+<header>
+    <h1 class="text-danger">@ViewData["Title"]</h1>
+    <p class="text-danger">This account has been locked out, please try again later.</p>
+</header>

--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Lockout.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Lockout.cshtml.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
+{
+    [AllowAnonymous]
+    public class LockoutModel : PageModel
+    {       
+        public void OnGet()
+        {
+        }
+    }
+}


### PR DESCRIPTION
User is redirected to /Identity/Account/Lockout endpoint when user account is locked. However, no page existed to handle the endpoint. Added Lockout.cshtml to handle this endpoint.