### PR TITLE
QRCode image keeps getting duplicated on enable authenticator page

### DIFF
--- a/src/Pixel.Identity.UI.Client/Pages/Authenticator/EnableAuthenticator.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Pages/Authenticator/EnableAuthenticator.razor.cs
@@ -26,6 +26,9 @@ namespace Pixel.Identity.UI.Client.Pages.Authenticator
         [Inject]
         public ISnackbar SnackBar { get; set; }
 
+        [Inject]
+        public IDialogService DialogService { get; set; }
+
         EnableAuthenticatorViewModel model = new();
         IJSObjectReference? module;
 
@@ -55,6 +58,7 @@ namespace Pixel.Identity.UI.Client.Pages.Authenticator
                 module = await JS.InvokeAsync<IJSObjectReference>("import", "./Pages/Authenticator/EnableAuthenticator.razor.js");               
             }
             await GenerateQRCodeAsync();
+
         }
 
         /// <summary>
@@ -73,6 +77,7 @@ namespace Pixel.Identity.UI.Client.Pages.Authenticator
                 });
                 return;
             }
+            await DialogService.ShowMessageBox("Success", "2FA is enabled and your account is more secure now. ");
             Navigator.NavigateTo("account/authenticator/manage");
         }
 

--- a/src/Pixel.Identity.UI.Client/Pages/Authenticator/EnableAuthenticator.razor.js
+++ b/src/Pixel.Identity.UI.Client/Pages/Authenticator/EnableAuthenticator.razor.js
@@ -1,6 +1,7 @@
 ﻿export function generateQrCode() {
     const uri = document.getElementById("qrCodeData").getAttribute('data-url');
-    if (uri == null) {
+    const title = document.getElementById("qrCode").getAttribute('title');
+    if (uri == null || title != null) {
         return;
     }
     new QRCode(document.getElementById("qrCode"),


### PR DESCRIPTION
1. Fixed an issue on enable authenticator page where duplicate QRCode images are added on page.
2. Added a success dialog on enabling authenticator before redirecting to other page.