### PR TITLE
Deserialization of IdentityRoleClaim<TKey> fails 

### DIFF
--- a/src/Pixel.Identity.Store.Mongo/AutoMapProfile.cs
+++ b/src/Pixel.Identity.Store.Mongo/AutoMapProfile.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using Microsoft.AspNetCore.Identity;
 using OpenIddict.Abstractions;
 using OpenIddict.MongoDb.Models;
 using Pixel.Identity.Shared.ViewModels;

--- a/src/Pixel.Identity.Store.Mongo/Extensions/IdentityBuilderExtensions.cs
+++ b/src/Pixel.Identity.Store.Mongo/Extensions/IdentityBuilderExtensions.cs
@@ -1,12 +1,9 @@
 ﻿using Dawn;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using MongoDB.Bson;
 using MongoDB.Driver;
 using Pixel.Identity.Store.Mongo.Models;
 using Pixel.Identity.Store.Mongo.Stores;
-using Pixel.Identity.Store.Mongo.Utils;
-using System.ComponentModel;
 
 namespace Pixel.Identity.Store.Mongo.Extensions
 {
@@ -14,7 +11,7 @@ namespace Pixel.Identity.Store.Mongo.Extensions
     {
         public static IdentityBuilder AddMongoDbStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>(this IdentityBuilder builder, MongoDbSettings dbSettings)
               where TUser : ApplicationUser<TKey, TUserClaim, TUserLogin, TUserToken>, new ()
-              where TRole : ApplicationRole<TKey>, new ()
+              where TRole : ApplicationRole<TKey, TRoleClaim>, new ()
               where TUserClaim : IdentityUserClaim<TKey>, new()
               where TRoleClaim : IdentityRoleClaim<TKey>, new()
               where TUserLogin : IdentityUserLogin<TKey>, new()

--- a/src/Pixel.Identity.Store.Mongo/Models/ApplicationRole.cs
+++ b/src/Pixel.Identity.Store.Mongo/Models/ApplicationRole.cs
@@ -8,7 +8,7 @@ namespace Pixel.Identity.Store.Mongo.Models
     /// <summary>
     /// ApplicationRole with <see cref="ObjectId"/> as the Identifier type
     /// </summary>
-    public class ApplicationRole : ApplicationRole<ObjectId>
+    public class ApplicationRole : ApplicationRole<ObjectId, IdentityRoleClaim>
     {
 
     }
@@ -16,11 +16,13 @@ namespace Pixel.Identity.Store.Mongo.Models
     /// <summary>
     /// ApplicationRole extends <see cref="IdentityRole{TKey}"/>
     /// </summary>
-    public class ApplicationRole<TKey> : IdentityRole<TKey>, IDocument<TKey> where TKey : IEquatable<TKey>
+    public class ApplicationRole<TKey, TRoleClaim> : IdentityRole<TKey>, IDocument<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>, new()
+        where TKey : IEquatable<TKey>
     {
         public int Version { get; set; } = 1;
 
-        public List<IdentityRoleClaim<TKey>> Claims { get; set; } = new();
+        public List<TRoleClaim> Claims { get; set; } = new();
 
         /// <summary>
         /// constructor

--- a/src/Pixel.Identity.Store.Mongo/MongoConfigurator.cs
+++ b/src/Pixel.Identity.Store.Mongo/MongoConfigurator.cs
@@ -6,8 +6,6 @@ using Pixel.Identity.Core;
 using Pixel.Identity.Core.Conventions;
 using Pixel.Identity.Store.Mongo.Extensions;
 using Pixel.Identity.Store.Mongo.Models;
-using Pixel.Identity.Store.Mongo.Utils;
-using System.ComponentModel;
 
 namespace Pixel.Identity.Store.Mongo
 {

--- a/src/Pixel.Identity.Store.Mongo/Stores/RoleStore.cs
+++ b/src/Pixel.Identity.Store.Mongo/Stores/RoleStore.cs
@@ -16,7 +16,7 @@ namespace Pixel.Identity.Store.Mongo.Stores
     /// <typeparam name="TRoleClaim">Type representing a <see cref="IdentityRoleClaim{TKey}"/></typeparam>
     /// <typeparam name="TKey">Identifier type for documents e.g. Guid or ObjectId</typeparam>
     public class RoleStore<TRole, TRoleClaim, TKey> : IQueryableRoleStore<TRole>, IRoleClaimStore<TRole>
-        where TRole : ApplicationRole<TKey>       
+        where TRole : ApplicationRole<TKey, TRoleClaim>       
         where TRoleClaim : IdentityRoleClaim<TKey>, new()
        where TKey : IEquatable<TKey>
     {

--- a/src/Pixel.Identity.Store.Mongo/Stores/UsersStore.cs
+++ b/src/Pixel.Identity.Store.Mongo/Stores/UsersStore.cs
@@ -22,7 +22,7 @@ namespace Pixel.Identity.Store.Mongo.Stores
     public class UserStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>
        : UserStoreBase<TUser, TRole, TKey, TUserClaim, TUserLogin, TUserToken,TRoleClaim>
        where TUser : ApplicationUser<TKey, TUserClaim, TUserLogin, TUserToken>
-       where TRole : ApplicationRole<TKey>
+       where TRole : ApplicationRole<TKey, TRoleClaim>
        where TUserClaim : IdentityUserClaim<TKey>, new()
        where TUserLogin : IdentityUserLogin<TKey>, new()
        where TUserToken : IdentityUserToken<TKey>, new()
@@ -677,7 +677,7 @@ namespace Pixel.Identity.Store.Mongo.Stores
         UserStoreBase<TUser, TKey, TUserClaim, TUserLogin, TUserToken>,
         IUserRoleStore<TUser>
         where TUser : ApplicationUser<TKey, TUserClaim, TUserLogin, TUserToken>
-        where TRole : ApplicationRole<TKey>
+        where TRole : ApplicationRole<TKey, TRoleClaim>
         where TKey : IEquatable<TKey>
         where TUserClaim : IdentityUserClaim<TKey>, new()        
         where TUserLogin : IdentityUserLogin<TKey>, new()


### PR DESCRIPTION
**Description**
For mongo based store, ApplicationRole<TKey> has Claims of type IdentityRoleClaim<TKey>.
        `public List<IdentityRoleClaim<TKey>> Claims { get; set; } = new();`
Deserialization fails while retrieving ApplicationRole since  property "Properties" doesn't exist on IdentityRoleClaim<TKey> but IdentityRoleClaim : IdentityRoleClaim<ObjectId>. 

**Fix**
Introduced TRoleClaim as a generic parameter on ApplicationRole so that we can pass a IdentityRoleClaim : IdentityRoleClaim<ObjectId> correctly.
