### PR TITLE
Avoid storing Id and RoleId/UserID properties for IdentityRoleClaim and IdentityUserClaim

### DIFF
--- a/src/Pixel.Identity.Store.Mongo/MongoConfigurator.cs
+++ b/src/Pixel.Identity.Store.Mongo/MongoConfigurator.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Identity;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using Pixel.Identity.Core;
 using Pixel.Identity.Core.Conventions;
@@ -33,6 +34,21 @@ namespace Pixel.Identity.Store.Mongo
         ///<inheritdoc/>
         public IdentityBuilder ConfigureIdentity(IConfiguration configuration, IServiceCollection services)
         {
+
+            BsonClassMap.RegisterClassMap<IdentityUserClaim<ObjectId>>(cm =>
+            {
+                cm.AutoMap();
+                cm.UnmapMember(m => m.Id);
+                cm.UnmapMember(m => m.UserId);
+            });
+
+            BsonClassMap.RegisterClassMap<IdentityRoleClaim<ObjectId>>(cm =>
+            {
+                cm.AutoMap();
+                cm.UnmapMember(m => m.Id);
+                cm.UnmapMember(m => m.RoleId);
+            });
+
             var mongoDbSettings = configuration.GetSection(nameof(MongoDbSettings)).Get<MongoDbSettings>();
             return services.AddIdentity<ApplicationUser, ApplicationRole>(options =>
             {

--- a/src/Pixel.Identity.Store.Mongo/Stores/RoleStore.cs
+++ b/src/Pixel.Identity.Store.Mongo/Stores/RoleStore.cs
@@ -192,12 +192,10 @@ namespace Pixel.Identity.Store.Mongo.Stores
         /// <param name="claim">The associated claim.</param>
         /// <returns>The role claim entity.</returns>
         protected virtual TRoleClaim CreateRoleClaim(TRole role, Claim claim)
-        {
-            var id = role.Claims.Count() + 1;
+        {            
             var roleClaim = new TRoleClaim()
             {
-                RoleId = role.Id,
-                Id = id
+                RoleId = role.Id               
             };
             roleClaim.InitializeFromClaim(claim);
             return roleClaim;

--- a/src/Pixel.Identity.Store.Mongo/Stores/UsersStore.cs
+++ b/src/Pixel.Identity.Store.Mongo/Stores/UsersStore.cs
@@ -609,12 +609,10 @@ namespace Pixel.Identity.Store.Mongo.Stores
 
         /// <inheritdoc/>
         protected override TUserClaim CreateUserClaim(TUser user, Claim claim)
-        {
-            int id = user.Claims.Count() + 1;
+        {            
             var roleClaim = new TUserClaim()
             {
-                UserId = user.Id,
-                Id = id
+                UserId = user.Id               
             };
             roleClaim.InitializeFromClaim(claim);
             return roleClaim;


### PR DESCRIPTION
**Description**
Id , RoleId and UserId properties on  IdentityRoleClaim<TKey> and IdentityUserClaim<TKey> are required when working with a relational database such as SqlServer. These don't make sense for a document based database like MongoDb.