### PR TITLE
Fixed issue with PostgreSQL plugin

### DIFF
--- a/src/Pixel.Identity.Store.Mongo/Extensions/IdentityBuilderExtensions.cs
+++ b/src/Pixel.Identity.Store.Mongo/Extensions/IdentityBuilderExtensions.cs
@@ -30,12 +30,12 @@ namespace Pixel.Identity.Store.Mongo.Extensions
 
             builder.Services.TryAddScoped<IUserStore<TUser>>(provider =>
             {
-                return new UserStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>(usersCollection, rolesCollection, identityErrorDescriber);
+                return new ApplicationUserStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>(usersCollection, rolesCollection, identityErrorDescriber);
             });
 
             builder.Services.TryAddScoped<IRoleStore<TRole>>(provider =>
             {
-                return new RoleStore<TRole, TRoleClaim, TKey>(rolesCollection, identityErrorDescriber);
+                return new ApplicationRoleStore<TRole, TRoleClaim, TKey>(rolesCollection, identityErrorDescriber);
             });
 
             return builder;

--- a/src/Pixel.Identity.Store.Mongo/Stores/ApplicationRoleStore.cs
+++ b/src/Pixel.Identity.Store.Mongo/Stores/ApplicationRoleStore.cs
@@ -15,7 +15,7 @@ namespace Pixel.Identity.Store.Mongo.Stores
     /// <typeparam name="TRole">Type representing a <see cref="IdentityRole{TKey}"/></typeparam>
     /// <typeparam name="TRoleClaim">Type representing a <see cref="IdentityRoleClaim{TKey}"/></typeparam>
     /// <typeparam name="TKey">Identifier type for documents e.g. Guid or ObjectId</typeparam>
-    public class RoleStore<TRole, TRoleClaim, TKey> : IQueryableRoleStore<TRole>, IRoleClaimStore<TRole>
+    public class ApplicationRoleStore<TRole, TRoleClaim, TKey> : IQueryableRoleStore<TRole>, IRoleClaimStore<TRole>
         where TRole : ApplicationRole<TKey, TRoleClaim>       
         where TRoleClaim : IdentityRoleClaim<TKey>, new()
        where TKey : IEquatable<TKey>
@@ -36,7 +36,7 @@ namespace Pixel.Identity.Store.Mongo.Stores
         /// </summary>
         /// <param name="rolesCollection"></param>
         /// <param name="describer"></param>
-        public RoleStore(IMongoCollection<TRole> rolesCollection, IdentityErrorDescriber describer)
+        public ApplicationRoleStore(IMongoCollection<TRole> rolesCollection, IdentityErrorDescriber describer)
         {
             this.rolesCollection = rolesCollection;
             this.ErrorDescriber = describer ?? new IdentityErrorDescriber();

--- a/src/Pixel.Identity.Store.Mongo/Stores/ApplicationUserStore.cs
+++ b/src/Pixel.Identity.Store.Mongo/Stores/ApplicationUserStore.cs
@@ -19,7 +19,7 @@ namespace Pixel.Identity.Store.Mongo.Stores
     /// <typeparam name="TUserToken">Type representing a <see cref="IdentityUserToken{TKey}"/></typeparam>
     /// <typeparam name="TRoleClaim">Type representing a <see cref="IdentityRoleClaim{TKey}"/></typeparam>
     /// <typeparam name="TKey">Identifier type for documents e.g. Guid or ObjectId</typeparam>
-    public class UserStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>
+    public class ApplicationUserStore<TUser, TRole, TUserClaim, TUserLogin, TUserToken, TRoleClaim, TKey>
        : UserStoreBase<TUser, TRole, TKey, TUserClaim, TUserLogin, TUserToken,TRoleClaim>
        where TUser : ApplicationUser<TKey, TUserClaim, TUserLogin, TUserToken>
        where TRole : ApplicationRole<TKey, TRoleClaim>
@@ -45,7 +45,7 @@ namespace Pixel.Identity.Store.Mongo.Stores
         /// </summary>
         /// <param name="rolesCollection"></param>
         /// <param name="describer"></param>
-        public UserStore(IMongoCollection<TUser> usersCollection, IMongoCollection<TRole> rolesCollection, IdentityErrorDescriber describer)
+        public ApplicationUserStore(IMongoCollection<TUser> usersCollection, IMongoCollection<TRole> rolesCollection, IdentityErrorDescriber describer)
             : base(describer)
         {
             this.usersCollection = usersCollection;

--- a/src/Pixel.Identity.Store.PostgreSQL/SqlConfigurator.cs
+++ b/src/Pixel.Identity.Store.PostgreSQL/SqlConfigurator.cs
@@ -47,8 +47,8 @@ public class SqlConfigurator : IConfigurator
             options.SignIn.RequireConfirmedAccount = true;
         })
        .AddRoles<ApplicationRole>()
-       .AddRoleStore<RoleStore>()
-       .AddUserStore<UserStore>();
+       .AddRoleStore<ApplicationRoleStore>()
+       .AddUserStore<ApplicationUserStore>();
     }
 
     ///<inheritdoc/>

--- a/src/Pixel.Identity.Store.Sql.Shared/Stores/ApplicationRoleStore.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Stores/ApplicationRoleStore.cs
@@ -1,10 +1,10 @@
 ﻿namespace Pixel.Identity.Store.Sql.Shared.Stores;
 
-public class RoleStore : RoleStore<ApplicationRole, ApplicationDbContext, Guid, IdentityUserRole<Guid>, IdentityRoleClaim>
+public class ApplicationRoleStore : RoleStore<ApplicationRole, ApplicationDbContext, Guid, IdentityUserRole<Guid>, IdentityRoleClaim>
 {
     private DbSet<IdentityRoleClaim> RoleClaims { get { return Context.Set<IdentityRoleClaim>(); } }
 
-    public RoleStore(ApplicationDbContext context, IdentityErrorDescriber describer = null)
+    public ApplicationRoleStore(ApplicationDbContext context, IdentityErrorDescriber describer = null)
         : base(context, describer)
     {
     }

--- a/src/Pixel.Identity.Store.Sql.Shared/Stores/ApplicationUserStore.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Stores/ApplicationUserStore.cs
@@ -1,10 +1,10 @@
 ﻿namespace Pixel.Identity.Store.Sql.Shared.Stores;
 
-public class UsersStore : UserStore<ApplicationUser, ApplicationRole, ApplicationDbContext, Guid,
+public class ApplicationUserStore : UserStore<ApplicationUser, ApplicationRole, ApplicationDbContext, Guid,
     IdentityUserClaim, IdentityUserRole<Guid>, IdentityUserLogin<Guid>,
     IdentityUserToken<Guid>, IdentityRoleClaim>
 {
-    public UsersStore(ApplicationDbContext context, IdentityErrorDescriber describer = null)
+    public ApplicationUserStore(ApplicationDbContext context, IdentityErrorDescriber describer = null)
         : base(context, describer)
     {
     }

--- a/src/Pixel.Identity.Store.SqlServer/SqlConfigurator.cs
+++ b/src/Pixel.Identity.Store.SqlServer/SqlConfigurator.cs
@@ -47,8 +47,8 @@ public class SqlConfigurator : IConfigurator
             options.SignIn.RequireConfirmedAccount = true;
         })
        .AddRoles<ApplicationRole>()
-       .AddRoleStore<RoleStore>()
-       .AddUserStore<UsersStore>();
+       .AddRoleStore<ApplicationRoleStore>()
+       .AddUserStore<ApplicationUserStore>();
     }
 
     ///<inheritdoc/>


### PR DESCRIPTION
**Description**
Due to a typo with AddUserStore<UserStore> instead of AddUserStore<UsersStore> where UsersStore is a local type but UserStore is Asp.Net identity type , plugin will fail to initialize properly. Renamed UserStore and RoleStore to ApplicationUserStore and ApplicationRoleStore to avoid such typos.