### PR TITLE
Updating any property on confidential application should not require secret to be provided on each udpate

### DIFF
--- a/src/Pixel.Identity.Core/Controllers/ApplicationsController.cs
+++ b/src/Pixel.Identity.Core/Controllers/ApplicationsController.cs
@@ -72,6 +72,13 @@ namespace Pixel.Identity.Core.Controllers
                     if (existing != null)
                     {
                         var openIdApplicationDescriptor = mapper.Map<OpenIddictApplicationDescriptor>(applicationDescriptor);
+                        //No new secret to update. Populate existing on descriptor before updating
+                        if(applicationDescriptor.IsConfidentialClient && string.IsNullOrEmpty(applicationDescriptor.ClientSecret))
+                        {
+                            var descriptorFromExisting = new OpenIddictApplicationDescriptor();
+                            await applicationManager.PopulateAsync(descriptorFromExisting, existing);
+                            openIdApplicationDescriptor.ClientSecret = descriptorFromExisting.ClientSecret;                          
+                        }                     
                         await applicationManager.UpdateAsync(existing, openIdApplicationDescriptor, CancellationToken.None);
                         return Ok();
                     }


### PR DESCRIPTION
**Description**
While trying to update a property on a confidential application e.g. adding a new permission, it should be possible to update without specifying the secret. Currently, we are getting a validation error from OpenIddict if secret is empty while trying to update.