### PR TITLE
Creating a new role or scope should redirect to list page

### DIFF
--- a/src/Pixel.Identity.UI.Client/Components/AddClaimDialog.razor
+++ b/src/Pixel.Identity.UI.Client/Components/AddClaimDialog.razor
@@ -9,7 +9,7 @@
                       Variant="Variant.Text" Immediate="true"></MudTextField>
         <MudTextField @bind-Value="@model.Value" Label="Value" @onfocus="(() => error = string.Empty)"
                       Variant="Variant.Text" Immediate="true"></MudTextField>
-
+        <br/>
         <MudSwitch @bind-Checked="model.IncludeInAccessToken" Label="Include in access token" Color="Color.Primary" />
 
         <MudSwitch @bind-Checked="model.IncludeInIdentityToken" Label="Include in identity token" Color="Color.Primary" />

--- a/src/Pixel.Identity.UI.Client/Components/AddClaimDialog.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Components/AddClaimDialog.razor.cs
@@ -35,10 +35,16 @@ namespace Pixel.Identity.UI.Client.Components
                 //Don't try to add claim to role if role is not yet created.
                 if (!string.IsNullOrEmpty(Owner))
                 {
-                    await Service.AddClaimAsync(Owner, model);
+                    var result = await Service.AddClaimAsync(Owner, model);
+                    if (result.IsSuccess)
+                    {
+                        MudDialog.Close(DialogResult.Ok<ClaimViewModel>(model));
+                        return;
+                    }
+                    error = result.ToString();
+                    return;
                 }
-                MudDialog.Close(DialogResult.Ok<ClaimViewModel>(model));
-                return;
+             
             }
             error = $"Claim with type {model.Type} already exists for role.";
         }

--- a/src/Pixel.Identity.UI.Client/Pages/Roles/AddRole.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Pages/Roles/AddRole.razor.cs
@@ -2,13 +2,12 @@
 using MudBlazor;
 using Pixel.Identity.Shared.ViewModels;
 using Pixel.Identity.UI.Client.Services;
-using System;
 using System.Threading.Tasks;
 
 namespace Pixel.Identity.UI.Client.Pages.Roles
 {
     /// <summary>
-    /// Component to add new roles
+    /// Add role view allows user to create a new Asp.Net Identity Role/>
     /// </summary>
     public partial class AddRole : ComponentBase
     {
@@ -20,7 +19,10 @@ namespace Pixel.Identity.UI.Client.Pages.Roles
 
         [Inject]
         public ISnackbar SnackBar { get; set; }
-      
+
+        [Inject]
+        public NavigationManager Navigator { get; set; }
+
         UserRoleViewModel model = new UserRoleViewModel(string.Empty);
 
         /// <summary>
@@ -29,24 +31,18 @@ namespace Pixel.Identity.UI.Client.Pages.Roles
         /// <returns></returns>
         async Task AddRoleAsync()
         {
-            if (!string.IsNullOrEmpty(model.RoleName))
+            var result = await UserRolesService.CreateRoleAsync(model);
+            if (result.IsSuccess)
             {
-                try
-                {
-                    var result = await UserRolesService.CreateRoleAsync(model);
-                    if(result.IsSuccess)
-                    {
-                        SnackBar.Add("Added successfully.", Severity.Success);
-                        model = new UserRoleViewModel(string.Empty);
-                        return;
-                    }
-                    SnackBar.Add(result.ToString(), Severity.Error);
-                }
-                catch (Exception ex)
-                {
-                    SnackBar.Add(ex.Message, Severity.Error);
-                }                  
+                SnackBar.Add("Added successfully.", Severity.Success);
+                Navigator.NavigateTo($"roles/list");
+                return;
             }
+            SnackBar.Add(result.ToString(), Severity.Error, config =>
+            {
+                config.ShowCloseIcon = true;
+                config.RequireInteraction = true;
+            });
         }
     }
 }

--- a/src/Pixel.Identity.UI.Client/Pages/Scopes/AddScope.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Pages/Scopes/AddScope.razor.cs
@@ -19,7 +19,11 @@ namespace Pixel.Identity.UI.Client.Pages.Scopes
 
         [Inject]
         public ISnackbar SnackBar { get; set; }
-      
+
+        [Inject]
+        public NavigationManager Navigator { get; set; }
+
+
         ScopeViewModel scope = new ScopeViewModel();
 
         /// <summary>
@@ -31,8 +35,8 @@ namespace Pixel.Identity.UI.Client.Pages.Scopes
             var result = await Service.AddScopeAsync(scope);
             if (result.IsSuccess)
             {
-                SnackBar.Add("Added successfully.", Severity.Success);
-                scope = new ScopeViewModel();
+                Navigator.NavigateTo($"scopes/list");
+                SnackBar.Add("Added successfully.", Severity.Success);              
                 return;
             }
             SnackBar.Add(result.ToString(), Severity.Error, config =>

--- a/src/Pixel.Identity.UI.Client/Pages/Scopes/EditScope.razor
+++ b/src/Pixel.Identity.UI.Client/Pages/Scopes/EditScope.razor
@@ -1,10 +1,11 @@
 ﻿@page "/scopes/edit/{Id?}"
 @attribute [Authorize(Policy = Policies.CanManageScopes)]
 
+<MudText Typo="Typo.h4">Edit Scope</MudText>
+<br />
+
 @if (scope != null)
 {
-    <MudText Typo="Typo.h4">Edit Scope</MudText>
-    <br />
     <MudPaper Elevation="4">
         <EditForm Model="@scope" OnValidSubmit="UpdateScopeAsync">
             <FluentValidator />
@@ -20,5 +21,9 @@
             </MudCard>
         </EditForm>
     </MudPaper>
+}
 
+@if (hasErrors)
+{
+    <MudAlert Severity="Severity.Error">Scope details could not be retrieved for scopeId : @(Id ?? string.Empty).</MudAlert>
 }

--- a/src/Pixel.Identity.UI.Client/Pages/Scopes/EditScope.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Pages/Scopes/EditScope.razor.cs
@@ -26,26 +26,15 @@ namespace Pixel.Identity.UI.Client.Pages.Scopes
 
         ScopeViewModel scope;
 
+        bool hasErrors = false;
+
         /// <summary>
         /// Retrieve the Scope details when Id parameter is set
         /// </summary>
         /// <returns></returns>
         protected override async Task OnParametersSetAsync()
         {
-            try
-            {
-                if (!string.IsNullOrEmpty(Id))
-                {
-                    this.scope = await Service.GetByIdAsync(Id);
-                    return;
-                }
-            }
-            catch (Exception ex)
-            {
-                SnackBar.Add($"Failed to retrieve scope. {ex.Message}", Severity.Error);
-            }
-
-            SnackBar.Add("No role specified to edit.", Severity.Error);
+            this.scope = await GetScopeDetailsAsync(Id);
         }
 
         /// <summary>
@@ -57,8 +46,8 @@ namespace Pixel.Identity.UI.Client.Pages.Scopes
             var result = await Service.UpdateScopeAsync(scope);
             if (result.IsSuccess)
             {
-                this.scope = await Service.GetByIdAsync(Id);
-                SnackBar.Add("Updated successfully.", Severity.Success);              
+                SnackBar.Add("Updated successfully.", Severity.Success);
+                this.scope = await GetScopeDetailsAsync(Id);
                 return;
             }
             SnackBar.Add(result.ToString(), Severity.Error, config =>
@@ -66,6 +55,33 @@ namespace Pixel.Identity.UI.Client.Pages.Scopes
                 config.ShowCloseIcon = true;
                 config.RequireInteraction = true;
             });
+        }
+
+        /// <summary>
+        /// Retrieve scope details given scope id
+        /// </summary>
+        /// <param name="scopeId"></param>
+        /// <returns></returns>
+        private async Task<ScopeViewModel> GetScopeDetailsAsync(string scopeId)
+        {
+            if (!string.IsNullOrEmpty(scopeId))
+            {
+                try
+                {
+                    return await Service.GetByIdAsync(scopeId);
+                }
+                catch (Exception ex)
+                {
+                    hasErrors = true;
+                    SnackBar.Add($"Failed to retrieve scope data. {ex.Message}", Severity.Error);
+                }
+            }
+            else
+            {
+                hasErrors = true;
+                SnackBar.Add("No scopeId specified.", Severity.Error);
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
**Description**
- Creating a new role or scope should redirect to list page similar to create application experience.
- Fixed an issue with add new claim dialog where any error while adding claim was not checked and always treated as success.
- Updating a scope should retrieve Scope again from service.
- Consistent Snackbar for error scenarios which should show a close button and requires user to interact with dialog and close it.