### PR TITLE
Fix issue with updating role name 

### DIFF
--- a/src/Pixel.Identity.Core/Controllers/RolesController.cs
+++ b/src/Pixel.Identity.Core/Controllers/RolesController.cs
@@ -128,6 +128,13 @@ namespace Pixel.Identity.Core.Controllers
                 {
                     return NotFound(new NotFoundResponse($"Failed to find role with Id : {request.RoleId}"));
                 }
+             
+                var exists = await roleManager.FindByNameAsync(request.NewName);
+                if(exists != null)
+                {
+                    return BadRequest(new BadRequestResponse(new[] { $"A role already exists with name {request.NewName}" }));
+                }
+              
                 if ((!role.Name?.Equals(request.NewName)) ?? false)
                 {
                     await roleManager.SetRoleNameAsync(role, request.NewName);


### PR DESCRIPTION
**Description**
It is possible to update a role name so that it can be updated to a value of another existing role. This results in two role having same role name.