### PR TITLE
Lookup role by id instead of name for a consistent api experience

### DIFF
--- a/src/Pixel.Identity.Core/Controllers/RolesController.cs
+++ b/src/Pixel.Identity.Core/Controllers/RolesController.cs
@@ -38,14 +38,14 @@ namespace Pixel.Identity.Core.Controllers
         /// <summary>
         /// Get the details of role given role name
         /// </summary>
-        /// <param name="roleName">Name of the role</param>
+        /// <param name="id">Name of the role</param>
         /// <returns></returns>
-        [HttpGet("{roleName}")]
-        public async Task<ActionResult<UserRoleViewModel>> Get(string roleName)
+        [HttpGet("{id}")]
+        public async Task<ActionResult<UserRoleViewModel>> Get(string id)
         {
-            if (!string.IsNullOrEmpty(roleName))
+            if (!string.IsNullOrEmpty(id))
             {
-                var role = await this.roleManager.FindByNameAsync(roleName);
+                var role = await this.roleManager.FindByIdAsync(id);
                 if (role != null)
                 {
                     var userRoleViewModel = new UserRoleViewModel(role.Id.ToString(), role.Name);
@@ -57,7 +57,7 @@ namespace Pixel.Identity.Core.Controllers
                     return userRoleViewModel;
                 }
             }
-            return NotFound(new NotFoundResponse($"{roleName ?? ""} could not be located"));
+            return NotFound(new NotFoundResponse($"{id ?? ""} could not be located"));
         }
 
         /// <summary>

--- a/src/Pixel.Identity.UI.Client/Pages/Roles/EditRole.razor
+++ b/src/Pixel.Identity.UI.Client/Pages/Roles/EditRole.razor
@@ -1,4 +1,4 @@
-﻿@page "/roles/edit/{name?}"
+﻿@page "/roles/edit/{Id?}"
 @attribute [Authorize(Policy = Policies.CanManageRoles)]
 
 <MudText Typo="Typo.h4">Edit Role</MudText>
@@ -6,7 +6,7 @@
 
 @if (hasErrors)
 {
-    <MudAlert Severity="Severity.Error">Role details could not be retrieved for role : @(Name ?? string.Empty).</MudAlert>
+    <MudAlert Severity="Severity.Error">Role details could not be retrieved for roleId : @(Id ?? string.Empty).</MudAlert>
 }
 
 @if (model != null)
@@ -26,7 +26,7 @@
                 </MudCardContent>
                 <MudCardActions>
                     <MudButton id="btnUpdateRoleName" ButtonType="ButtonType.Submit" Variant="Variant.Filled"
-                           hidden="@(!canEditRoleName)" Disabled="@(Name.Equals(model.RoleName))"
+                           hidden="@(!canEditRoleName)" Disabled="@(roleName?.Equals(model.RoleName) ?? true)"
                            Color="Color.Primary" Class="ml-auto">Update</MudButton>
                 </MudCardActions>
             </MudCard>

--- a/src/Pixel.Identity.UI.Client/Pages/Roles/RoleList.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Pages/Roles/RoleList.razor.cs
@@ -90,7 +90,7 @@ namespace Pixel.Identity.UI.Client.Pages.Roles
         /// <param name="role"></param>
         protected void NavigateToEditRolePage(UserRoleViewModel role)
         {
-            Navigator.NavigateTo($"roles/edit/{role.RoleName}");
+            Navigator.NavigateTo($"roles/edit/{role.RoleId}");
         }
 
 

--- a/src/Pixel.Identity.UI.Client/Services/UserRolesService.cs
+++ b/src/Pixel.Identity.UI.Client/Services/UserRolesService.cs
@@ -27,7 +27,7 @@ namespace Pixel.Identity.UI.Client.Services
         /// </summary>
         /// <param name="roleName"></param>
         /// <returns></returns>
-        Task<UserRoleViewModel> GetRoleByNameAsync(string roleName);
+        Task<UserRoleViewModel> GetRoleByIdAsync(string roleName);
 
         /// <summary>
         /// Add a new role
@@ -99,10 +99,10 @@ namespace Pixel.Identity.UI.Client.Services
         }
 
         /// <inheritdoc/>
-        public async Task<UserRoleViewModel> GetRoleByNameAsync(string roleName)
+        public async Task<UserRoleViewModel> GetRoleByIdAsync(string roleId)
         {
             return await JsonSerializer.DeserializeAsync<UserRoleViewModel>
-                      (await httpClient.GetStreamAsync($"api/roles/{roleName}"), new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
+                      (await httpClient.GetStreamAsync($"api/roles/{roleId}"), new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
**Description**
Currently role is looked up by name while scopes and users are looked up by id. For a consistent api experience , lookup  role by id. This also has an advantage that while editing a role , the url api/edit/id doesn't point to outdated value since id doesn't change unlike old endpoint api/edit/rolename .