### PR TITLE
Incorrect error message displayed while adding a duplicate role

### DIFF
--- a/src/Pixel.Identity.Core/Controllers/AuthenticatorController.cs
+++ b/src/Pixel.Identity.Core/Controllers/AuthenticatorController.cs
@@ -134,7 +134,7 @@ namespace Pixel.Identity.Core.Controllers
             var disable2faResult = await userManager.SetTwoFactorEnabledAsync(user, false);
             if (!disable2faResult.Succeeded)
             {
-                return Problem(string.Join(Environment.NewLine, disable2faResult.Errors.Select(e => e.Description)));
+                return Problem(string.Join(Environment.NewLine, disable2faResult.GetErrors()));
             }
             return Ok();
         }

--- a/src/Pixel.Identity.Core/Controllers/RolesController.cs
+++ b/src/Pixel.Identity.Core/Controllers/RolesController.cs
@@ -108,7 +108,7 @@ namespace Pixel.Identity.Core.Controllers
                     }
                     return Ok();
                 }
-                return BadRequest(new BadRequestResponse(result.Errors.Select(e => e.ToString())));
+                return BadRequest(new BadRequestResponse(result.GetErrors()));
             }
             return BadRequest(new BadRequestResponse(ModelState.GetValidationErrors()));
         }
@@ -162,7 +162,7 @@ namespace Pixel.Identity.Core.Controllers
                         {
                             return Ok();
                         }
-                        return BadRequest(new BadRequestResponse(result.Errors.Select(e => e.ToString())));
+                        return BadRequest(new BadRequestResponse(result.GetErrors()));
                     }
                     return BadRequest(new BadRequestResponse(new[] { $"There are users with assigned role : {roleName}." }));
                 }

--- a/src/Pixel.Identity.Core/Controllers/UsersController.cs
+++ b/src/Pixel.Identity.Core/Controllers/UsersController.cs
@@ -145,7 +145,7 @@ namespace Pixel.Identity.Core.Controllers
                 {
                     return Ok();
                 }
-                return BadRequest(new BadRequestResponse(result.Errors.Select(e => e.Description)));
+                return BadRequest(new BadRequestResponse(result.GetErrors()));
             }
             return NotFound(new NotFoundResponse($"User with Id : {userId} doesn't exist"));
         }
@@ -177,7 +177,7 @@ namespace Pixel.Identity.Core.Controllers
                     {
                         return Ok();
                     }
-                    return BadRequest(new BadRequestResponse(result.Errors.Select(e => e.Description)));
+                    return BadRequest(new BadRequestResponse(result.GetErrors()));
                 }
                 return NotFound(new NotFoundResponse("User doesn't exist."));
             }

--- a/src/Pixel.Identity.Core/Extensions/IdentityErrorExtensions.cs
+++ b/src/Pixel.Identity.Core/Extensions/IdentityErrorExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace Pixel.Identity.Core.Extensions
+{
+    public static class IdentityErrorExtensions
+    {
+        public static IEnumerable<string> GetErrors(this IdentityResult identityResult)
+        {
+            return identityResult.Errors.Select(s => $"{s.Code}:{s.Description}").Distinct();
+        }
+    }
+}

--- a/src/Pixel.Identity.Core/Pixel.Identity.Core.csproj
+++ b/src/Pixel.Identity.Core/Pixel.Identity.Core.csproj
@@ -15,4 +15,9 @@
 		<PackageReference Include="OpenIddict.AspNetCore" Version="3.1.1" />
 	</ItemGroup>
 
+
+	<ItemGroup>
+		<Using Include="Pixel.Identity.Core.Extensions" />	
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
**Description**
IdentityError->ToString() returns the class name and not the underlying code and description. Added an extension method on IdentityResult called GetErrors() to get properly formatted unique errors.