### PR TITLE
Allow initial admin user and password to be configured

### DIFF
--- a/.config/identity-mongo-with-console-email.env
+++ b/.config/identity-mongo-with-console-email.env
@@ -1,5 +1,9 @@
 #Note __ will be replaced to : by asp.net 
 
+#Admin account to create on initialize
+InitAdminUser=admin@pixel.com
+InitAdminUserPass=Admi9@pixel
+
 #Plugin configuration
 Plugins__Collection__0__Type=EmailSender
 Plugins__Collection__0__Path=Plugins/Messenger

--- a/.config/identity-postgres-with-console-email.env
+++ b/.config/identity-postgres-with-console-email.env
@@ -1,4 +1,8 @@
-#Note __ will be replaced to : by asp.net 
+#Note __ will be replaced to : by asp.net
+
+#Admin account to create on initialize
+InitAdminUser=admin@pixel.com
+InitAdminUserPass=Admi9@pixel
 
 #Plugin configuration
 Plugins__Collection__0__Type=EmailSender

--- a/.config/identity.env
+++ b/.config/identity.env
@@ -2,6 +2,10 @@
 AllowedOrigins=https://pixel.docker.localhost
 IdentityHost=https://pixel.docker.localhost/pauth
 
+#Admin account to create on initialize
+InitAdminUser=admin@pixel.com
+InitAdminUserPass=Admi9@pixel
+
 #Plugin configuration
 Plugins__Collection__0__Type=EmailSender
 Plugins__Collection__0__Path=Plugins/Messenger

--- a/src/Pixel.Identity.Provider/appsettings.Development.json
+++ b/src/Pixel.Identity.Provider/appsettings.Development.json
@@ -1,4 +1,4 @@
-{  
+{
   "Plugins": {
     "Collection": [
       {
@@ -12,28 +12,6 @@
         "Name": "Pixel.Identity.Store.Mongo"
       }
     ]
-  },
-  "IdentityOptions": {
-    "SignIn": {
-      "RequireConfirmedAccount": false
-    }
-  },
-  "Identity": {
-    "Certificates": {
-      "EncryptionCertificatePath": "E:\\Git\\Pixel.Identity\\.certificates\\identity-encryption.pfx",
-      "EncryptionCertificateKey": "",
-      "SigningCertificatePath": "E:\\Git\\Pixel.Identity\\.certificates\\identity-signing.pfx",
-      "SigningCertificateKey": ""
-    }
-  },
-  "ConnectionStrings": {
-    "SqlServerConnection": "Server=(localdb)\\mssqllocaldb;Database=pixel-identity-db;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "PostgreServerConnection": "User ID=postgresadmin;Password=postgrespass;Server=postgres;Port=5432;Database=pixel_identity_db;"
-  },
-  "MongoDbSettings": {
-    "ConnectionString": "mongodb://localhost:27017",
-    "DatabaseName": "pixel-identity-db"
-  },
-  "IdentityHost": "http://localhost:44382/pauth",
-  "AllowedOrigins": "http://localhost:44382"
+  }
 }
+

--- a/src/Pixel.Identity.Store.Mongo/Worker.cs
+++ b/src/Pixel.Identity.Store.Mongo/Worker.cs
@@ -1,29 +1,37 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using OpenIddict.Abstractions;
 using Pixel.Identity.Store.Mongo.Models;
+using System.Configuration;
 using System.Security.Claims;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
-namespace Pixel.Identity.Store.Mongo
+namespace Pixel.Identity.Store.Mongo;
+
+/// <summary>
+/// Worker is reponsible for setting up the initial values in database
+/// </summary>
+public class Worker : IHostedService
 {
-    public class Worker : IHostedService
+    private readonly IServiceProvider serviceProvider;
+    private readonly IConfiguration configuration;
+     private readonly ILogger<Worker> logger;
+
+    public Worker(IServiceProvider serviceProvider, IConfiguration configuration, ILogger<Worker> logger)
     {
-        private readonly IServiceProvider serviceProvider;
-        private readonly IConfiguration configuration;
+        this.serviceProvider = serviceProvider;
+        this.configuration = configuration;
+        this.logger = logger;
+    }
 
-        public Worker(IServiceProvider serviceProvider, IConfiguration configuration)
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = this.serviceProvider.CreateScope();
+        
+        var applicationManager = scope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
+
+        if (await applicationManager.FindByClientIdAsync("pixel-identity-ui") is null)
         {
-            this.serviceProvider = serviceProvider;
-            this.configuration = configuration;
-        }
-
-        public async Task StartAsync(CancellationToken cancellationToken)
-        {
-            using var scope = this.serviceProvider.CreateScope();
-            
-            var applicationManager = scope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
-
-            if (await applicationManager.FindByClientIdAsync("pixel-identity-ui") is null)
+            if (!string.IsNullOrEmpty(configuration["IdentityHost"]))
             {
                 await applicationManager.CreateAsync(new OpenIddictApplicationDescriptor
                 {
@@ -32,83 +40,97 @@ namespace Pixel.Identity.Store.Mongo
                     DisplayName = "Pixel Identity",
                     Type = ClientTypes.Public,
                     PostLogoutRedirectUris =
-                    {
-                        new Uri($"{configuration["IdentityHost"]}/authentication/logout-callback")
-                    },
+            {
+                new Uri($"{configuration["IdentityHost"]}/authentication/logout-callback")
+            },
                     RedirectUris =
-                    {
-                        new Uri($"{configuration["IdentityHost"]}/authentication/login-callback")                       
-                    },
+            {
+                new Uri($"{configuration["IdentityHost"]}/authentication/login-callback")
+            },
                     Permissions =
-                    {
-                        Permissions.Endpoints.Authorization,
-                        Permissions.Endpoints.Logout,
-                        Permissions.Endpoints.Token,
-                        Permissions.Endpoints.Introspection,
-                        Permissions.GrantTypes.AuthorizationCode,
-                        Permissions.GrantTypes.RefreshToken,
-                        Permissions.ResponseTypes.Code,
-                        Permissions.Scopes.Email,
-                        Permissions.Scopes.Profile,
-                        Permissions.Scopes.Roles
-                    },
+            {
+                Permissions.Endpoints.Authorization,
+                Permissions.Endpoints.Logout,
+                Permissions.Endpoints.Token,
+                Permissions.Endpoints.Introspection,
+                Permissions.GrantTypes.AuthorizationCode,
+                Permissions.GrantTypes.RefreshToken,
+                Permissions.ResponseTypes.Code,
+                Permissions.Scopes.Email,
+                Permissions.Scopes.Profile,
+                Permissions.Scopes.Roles
+            },
                     Requirements =
-                    {
-                        Requirements.Features.ProofKeyForCodeExchange
-                    }
+            {
+                Requirements.Features.ProofKeyForCodeExchange
+            }
+                });
+                logger.LogInformation("Added application descriptor for pixel-identity-ui");
+            }
+            else
+            {
+                throw new ConfigurationErrorsException("A non-empty value is required for 'IdentityHost'");
+            }
+
+            var scopeManager = scope.ServiceProvider.GetRequiredService<IOpenIddictScopeManager>();
+            if (await scopeManager.CountAsync() == 0)
+            {
+                await scopeManager.CreateAsync(new OpenIddictScopeDescriptor()
+                {
+                    Name = "persistence-api",
+                    DisplayName = "Persistence Api"
                 });
 
-                var scopeManager = scope.ServiceProvider.GetRequiredService<IOpenIddictScopeManager>();
-                if (await scopeManager.CountAsync() == 0)
+                await scopeManager.CreateAsync(new OpenIddictScopeDescriptor()
                 {
-                    await scopeManager.CreateAsync(new OpenIddictScopeDescriptor()
-                    {
-                        Name = "persistence-api",
-                        DisplayName = "Persistence Api"
-                    });
+                    Name = "offline_access",
+                    DisplayName = "Offline Access"
+                });
+                logger.LogInformation("Added persistence-api and offline_access scopes");
+            }
 
-                    await scopeManager.CreateAsync(new OpenIddictScopeDescriptor()
-                    {
-                        Name = "offline_access",
-                        DisplayName = "Offline Access"
-                    });
-                }
-
-                var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<ApplicationRole>>();
-                if (roleManager.Roles.Count() == 0)
+            var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<ApplicationRole>>();
+            if (roleManager.Roles.Count() == 0)
+            {
+                await roleManager.CreateAsync(new ApplicationRole() { Name = "IdentityAdmin" });
+                var role = await roleManager.FindByNameAsync("IdentityAdmin");
+               
+                await AddClaimAsync("identity_read_write", "users");
+                await AddClaimAsync("identity_read_write", "roles");
+                await AddClaimAsync("identity_read_write", "applications");
+                await AddClaimAsync("identity_read_write", "scopes");
+               
+                async Task AddClaimAsync(string type, string value)
                 {
-                    await roleManager.CreateAsync(new ApplicationRole() { Name = "IdentityAdmin" });
-                    var role = await roleManager.FindByNameAsync("IdentityAdmin");
-                   
-                    await AddClaimAsync("identity_read_write", "users");
-                    await AddClaimAsync("identity_read_write", "roles");
-                    await AddClaimAsync("identity_read_write", "applications");
-                    await AddClaimAsync("identity_read_write", "scopes");
-                   
-                    async Task AddClaimAsync(string type, string value)
-                    {
-                        var claim = new Claim(type, value);
-                        claim.Properties.Add("IncludeInAccessToken", "true");
-                        claim.Properties.Add("IncludeInIdentityToken", "true");
-                        await roleManager.AddClaimAsync(role, claim);
-                    }
+                    var claim = new Claim(type, value);
+                    claim.Properties.Add("IncludeInAccessToken", "true");
+                    claim.Properties.Add("IncludeInIdentityToken", "true");
+                    await roleManager.AddClaimAsync(role, claim);
                 }
+                logger.LogInformation("Added role IdentityAdmin and required claims");
+            }
 
-                var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
-                if (userManager.Users.Count() == 0)
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            if (userManager.Users.Count() == 0)
+            {
+                if (!string.IsNullOrEmpty(configuration["InitAdminUser"]) && !string.IsNullOrEmpty(configuration["InitAdminUserPass"]))
                 {
                     var adminUser = new ApplicationUser();
-                    await userManager.SetUserNameAsync(adminUser, "admin@pixel.com");
-                    await userManager.SetEmailAsync(adminUser, "admin@pixel.com");
-                    await userManager.CreateAsync(adminUser, "Admi9@pixel");
+                    await userManager.SetUserNameAsync(adminUser, configuration["InitAdminUser"]);
+                    await userManager.SetEmailAsync(adminUser, configuration["InitAdminUser"]);
+                    await userManager.CreateAsync(adminUser, configuration["InitAdminUserPass"]);
                     await userManager.ConfirmEmailAsync(adminUser, await userManager.GenerateEmailConfirmationTokenAsync(adminUser));
-
                     //assign IdentityAdmin role to user
                     await userManager.AddToRoleAsync(adminUser, "IdentityAdmin");
+                    logger.LogInformation("Added InitAdminUser and assigned IdentityAdmin role to it.");
+                }
+                else
+                {
+                    throw new ConfigurationErrorsException("A non - empty value is required for 'InitAdminUser' and 'InitAdminUserPass'") ;
                 }
             }
         }
-
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/src/Pixel.Identity.Store.SqlServer/Worker.cs
+++ b/src/Pixel.Identity.Store.SqlServer/Worker.cs
@@ -1,17 +1,23 @@
 ﻿using OpenIddict.Abstractions;
+using System.Configuration;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace Pixel.Identity.Store.SqlServer;
 
+/// <summary>
+/// Worker is reponsible for setting up the initial values in database
+/// </summary>
 public class Worker : IHostedService
 {
     private readonly IServiceProvider serviceProvider;
     private readonly IConfiguration configuration;
+    private readonly ILogger<Worker> logger;
 
-    public Worker(IServiceProvider serviceProvider, IConfiguration configuration)
+    public Worker(IServiceProvider serviceProvider, IConfiguration configuration, ILogger<Worker> logger)
     {
         this.serviceProvider = serviceProvider;
         this.configuration = configuration;
+        this.logger = logger;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -25,21 +31,23 @@ public class Worker : IHostedService
 
         if (await applicationManager.FindByClientIdAsync("pixel-identity-ui") is null)
         {
-            await applicationManager.CreateAsync(new OpenIddictApplicationDescriptor
+            if (!string.IsNullOrEmpty(configuration["IdentityHost"]))
             {
-                ClientId = "pixel-identity-ui",
-                ConsentType = ConsentTypes.Implicit,
-                DisplayName = "Pixel Identity",
-                Type = ClientTypes.Public,
-                PostLogoutRedirectUris =
+                await applicationManager.CreateAsync(new OpenIddictApplicationDescriptor
+                {
+                    ClientId = "pixel-identity-ui",
+                    ConsentType = ConsentTypes.Implicit,
+                    DisplayName = "Pixel Identity",
+                    Type = ClientTypes.Public,
+                    PostLogoutRedirectUris =
                 {
                     new Uri($"{configuration["IdentityHost"]}/authentication/logout-callback")
                 },
-                RedirectUris =
+                    RedirectUris =
                 {
-                    new Uri($"{configuration["IdentityHost"]}/authentication/login-callback")                       
+                    new Uri($"{configuration["IdentityHost"]}/authentication/login-callback")
                 },
-                Permissions =
+                    Permissions =
                 {
                     Permissions.Endpoints.Authorization,
                     Permissions.Endpoints.Logout,
@@ -52,11 +60,17 @@ public class Worker : IHostedService
                     Permissions.Scopes.Profile,
                     Permissions.Scopes.Roles
                 },
-                Requirements =
+                    Requirements =
                 {
                     Requirements.Features.ProofKeyForCodeExchange
                 }
-            });               
+                });
+                logger.LogInformation("Added application descriptor for pixel-identity-ui");
+            }
+            else
+            {
+                throw new ConfigurationErrorsException("A non-empty value is required for 'IdentityHost'");
+            }
         }
 
         var scopeManager = scope.ServiceProvider.GetRequiredService<IOpenIddictScopeManager>();
@@ -73,6 +87,7 @@ public class Worker : IHostedService
                 Name = "offline_access",
                 DisplayName = "Offline Access"
             });
+            logger.LogInformation("Added persistence-api and offline_access scopes");
         }
 
         var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<ApplicationRole>>();
@@ -93,18 +108,27 @@ public class Worker : IHostedService
                 claim.Properties.Add("IncludeInIdentityToken", "true");
                 await roleManager.AddClaimAsync(role, claim);
             }
+            logger.LogInformation("Added role IdentityAdmin and required claims");
         }
 
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
         if(userManager.Users.Count() == 0)
         {
-            var adminUser = new ApplicationUser();
-            await userManager.SetUserNameAsync(adminUser, "admin@pixel.com");
-            await userManager.SetEmailAsync(adminUser, "admin@pixel.com");
-            await userManager.CreateAsync(adminUser, "Admi9@pixel");
-            await userManager.ConfirmEmailAsync(adminUser, await userManager.GenerateEmailConfirmationTokenAsync(adminUser));
-            //assign IdentityAdmin role to user
-            await userManager.AddToRoleAsync(adminUser, "IdentityAdmin");
+            if (!string.IsNullOrEmpty(configuration["InitAdminUser"]) && !string.IsNullOrEmpty(configuration["InitAdminUserPass"]))
+            {
+                var adminUser = new ApplicationUser();
+                await userManager.SetUserNameAsync(adminUser, configuration["InitAdminUser"]);
+                await userManager.SetEmailAsync(adminUser, configuration["InitAdminUser"]);
+                await userManager.CreateAsync(adminUser, configuration["InitAdminUserPass"]);
+                await userManager.ConfirmEmailAsync(adminUser, await userManager.GenerateEmailConfirmationTokenAsync(adminUser));
+                //assign IdentityAdmin role to user
+                await userManager.AddToRoleAsync(adminUser, "IdentityAdmin");
+                logger.LogInformation("Added InitAdminUser and assigned IdentityAdmin role to it.");
+            }
+            else
+            {
+                throw new ConfigurationErrorsException("A non-empty value is required for 'InitAdminUser' and 'InitAdminUserPass'");
+            }
         }           
     }
 


### PR DESCRIPTION
**Description**
Default admin user and password were hard coded in Worker files responsible for setting up the initial values in database.
It should be possible for a user to pass the initial admin user and password values in to Asp.Net configuration system. The worker should retrieve the values from the configuration and use them.