### PR TITLE
Enable Task Test_That_Can_Not_Create_Duplicate_Scope test

### DIFF
--- a/src/Pixel.Identity.UI.Tests/Tests/ApplicationsFixture.cs
+++ b/src/Pixel.Identity.UI.Tests/Tests/ApplicationsFixture.cs
@@ -155,7 +155,7 @@ internal class ApplicationsFixture : PageSesionTest
         },
         new PageRunAndWaitForNavigationOptions()
         {
-               UrlRegex = new System.Text.RegularExpressions.Regex(".*/applications/list")
+               UrlRegex = new Regex(".*/applications/list")
         });
         //wait for the snackbar to show up
         await this.Page.Locator("div.mud-snackbar").WaitForAsync(new LocatorWaitForOptions()

--- a/src/Pixel.Identity.UI.Tests/Tests/ScopesFixture.cs
+++ b/src/Pixel.Identity.UI.Tests/Tests/ScopesFixture.cs
@@ -120,8 +120,7 @@ namespace Pixel.Identity.UI.Tests
         /// <param name="scopeName">Duplicate scope name</param>
         /// <returns></returns>
         [Order(35)]
-        [TestCase("scope-01")]
-        [Ignore("To fix error reponse")]
+        [TestCase("scope-01")]      
         public async Task Test_That_Can_Not_Create_Duplicate_Scope(string scopeName)
         {
             var listScopesPage = new ListScopesPage(this.Page);


### PR DESCRIPTION
**Description**
Enable back one of the ignored test for verifying it should not be possible to create a duplicate scope.