### PR TITLE
Downgrade Npgsql.EntityFrameworkCore.PostgreSQL to 6.x

### DIFF
--- a/src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.PostgreSQL.csproj
+++ b/src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.PostgreSQL.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="OpenIddict.Quartz" Version="4.2.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />	
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />	
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
PostgreSQL plugin fails to load due to some dependencies pulled by  Npgsql.EntityFrameworkCore.PostgreSQL 7.x which are higher than  used in other places. Hence, downgrade to 6.x