### PR TITLE
Upgrade dependencies

### DIFF
--- a/src/Pixel.Identity.Core/Pixel.Identity.Core.csproj
+++ b/src/Pixel.Identity.Core/Pixel.Identity.Core.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="12.0.1" />		
-		<PackageReference Include="OpenIddict.AspNetCore" Version="4.2.0" />
+		<PackageReference Include="OpenIddict.AspNetCore" Version="4.6.0" />
 	</ItemGroup>
 
 

--- a/src/Pixel.Identity.Messenger.Email/Pixel.Identity.Messenger.Email.csproj
+++ b/src/Pixel.Identity.Messenger.Email/Pixel.Identity.Messenger.Email.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MailKit" Version="3.6.0" />
+		<PackageReference Include="MailKit" Version="4.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Identity.Provider/Pixel.Identity.Provider.csproj
+++ b/src/Pixel.Identity.Provider/Pixel.Identity.Provider.csproj
@@ -13,18 +13,18 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="12.0.1" />
-		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
-		<PackageReference Include="MailKit" Version="3.6.0" />
+		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+		<PackageReference Include="MailKit" Version="4.1.0" />
 		<PackageReference Include="McMaster.NETCore.Plugins.Mvc" Version="1.4.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="6.0.4" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.4" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" />	
-		<PackageReference Include="OpenIddict.AspNetCore" Version="4.2.0" />
-		<PackageReference Include="OpenIddict.Quartz" Version="4.2.0" />
-		<PackageReference Include="Quartz.Extensions.Hosting" Version="3.6.2" />
-		<PackageReference Include="MudBlazor" Version="6.0.9" />
-		<PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+		<PackageReference Include="OpenIddict.AspNetCore" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0" />
+		<PackageReference Include="Quartz.Extensions.Hosting" Version="3.7.0" />
+		<PackageReference Include="MudBlazor" Version="6.8.0" />
+		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />		
 	</ItemGroup>

--- a/src/Pixel.Identity.Shared/Pixel.Identity.Shared.csproj
+++ b/src/Pixel.Identity.Shared/Pixel.Identity.Shared.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>      
-    <PackageReference Include="OpenIddict.Abstractions" Version="4.2.0" />    
+    <PackageReference Include="OpenIddict.Abstractions" Version="4.6.0" />    
   </ItemGroup>
 </Project>

--- a/src/Pixel.Identity.Store.Mongo/Pixel.Identity.Store.Mongo.csproj
+++ b/src/Pixel.Identity.Store.Mongo/Pixel.Identity.Store.Mongo.csproj
@@ -13,14 +13,14 @@
 		</PackageReference>		
 		<PackageReference Include="Dawn.Guard" Version="1.12.0" />	
 		<PackageReference Include="MongoDB.Driver" Version="2.18.0" />
-		<PackageReference Include="OpenIddict.Abstractions" Version="4.2.0">
+		<PackageReference Include="OpenIddict.Abstractions" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.Quartz" Version="4.2.0">
+		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.MongoDb" Version="4.2.0" />
-		<PackageReference Include="OpenIddict.MongoDb.Models" Version="4.2.0" />		
+		<PackageReference Include="OpenIddict.MongoDb" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.MongoDb.Models" Version="4.6.0" />		
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.PostgreSQL.csproj
+++ b/src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.PostgreSQL.csproj
@@ -14,15 +14,15 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.2.0" />
-		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.2.0" />
-		<PackageReference Include="OpenIddict.Abstractions" Version="4.2.0">
+		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.Abstractions" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.Quartz" Version="4.2.0">
+		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />	
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />	
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.PostgreSQL.csproj
+++ b/src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.PostgreSQL.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />	
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />	
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Identity.Store.Sql.Shared/Pixel.Identity.Store.Sql.Shared.csproj
+++ b/src/Pixel.Identity.Store.Sql.Shared/Pixel.Identity.Store.Sql.Shared.csproj
@@ -14,12 +14,12 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.2.0" />
-		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.2.0" />
-		<PackageReference Include="OpenIddict.Abstractions" Version="4.2.0">
+		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.Abstractions" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.Quartz" Version="4.2.0">
+		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>		
 	</ItemGroup>

--- a/src/Pixel.Identity.Store.SqlServer/Pixel.Identity.Store.SqlServer.csproj
+++ b/src/Pixel.Identity.Store.SqlServer/Pixel.Identity.Store.SqlServer.csproj
@@ -14,12 +14,12 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>		
-		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.2.0" />
-		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.2.0" />
-		<PackageReference Include="OpenIddict.Abstractions" Version="4.2.0">
+		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.Abstractions" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.Quartz" Version="4.2.0">
+		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>		
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />

--- a/src/Pixel.Identity.UI.Client/Pixel.Identity.UI.Client.csproj
+++ b/src/Pixel.Identity.UI.Client/Pixel.Identity.UI.Client.csproj
@@ -6,13 +6,13 @@
 
   <ItemGroup>    
     <PackageReference Include="Blazored.FluentValidation" Version="2.1.0" />    
-    <PackageReference Include="FluentValidation" Version="11.5.1" />
+    <PackageReference Include="FluentValidation" Version="11.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="MudBlazor" Version="6.0.9" />
+    <PackageReference Include="MudBlazor" Version="6.8.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
+++ b/src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
@@ -9,12 +9,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.32.0" />
-    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.32.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.37.0" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.37.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
**Description**
OpenIdDict -> 4.6
Mudblazor -> 6.8

**Notes**
We could not upgrade OpenIdDict to 4.7 due to a blocker with MongoDb. 
Raised question for any workaround -> https://github.com/openiddict/openiddict-core/issues/1861
Existing issue on Mongo Repo -> https://jira.mongodb.org/browse/CSHARP-4535?attachmentOrder=desc