### PR TITLE
Updated openiddict to 4.7.0 and mongodb to 2.21.0

### DIFF
--- a/src/Pixel.Identity.Core/Pixel.Identity.Core.csproj
+++ b/src/Pixel.Identity.Core/Pixel.Identity.Core.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="12.0.1" />		
-		<PackageReference Include="OpenIddict.AspNetCore" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.AspNetCore" Version="4.7.0" />
 	</ItemGroup>
 
 

--- a/src/Pixel.Identity.Provider/Pixel.Identity.Provider.csproj
+++ b/src/Pixel.Identity.Provider/Pixel.Identity.Provider.csproj
@@ -20,8 +20,8 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.4" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" />	
-		<PackageReference Include="OpenIddict.AspNetCore" Version="4.6.0" />
-		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0" />
+		<PackageReference Include="OpenIddict.AspNetCore" Version="4.7.0" />
+		<PackageReference Include="OpenIddict.Quartz" Version="4.7.0" />
 		<PackageReference Include="Quartz.Extensions.Hosting" Version="3.7.0" />
 		<PackageReference Include="MudBlazor" Version="6.8.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/src/Pixel.Identity.Shared/Pixel.Identity.Shared.csproj
+++ b/src/Pixel.Identity.Shared/Pixel.Identity.Shared.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>      
-    <PackageReference Include="OpenIddict.Abstractions" Version="4.6.0" />    
+    <PackageReference Include="OpenIddict.Abstractions" Version="4.7.0" />    
   </ItemGroup>
 </Project>

--- a/src/Pixel.Identity.Store.Mongo/MongoConfigurator.cs
+++ b/src/Pixel.Identity.Store.Mongo/MongoConfigurator.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Identity;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Configuration;
+using MongoDB.Driver.Linq;
 using Pixel.Identity.Core;
 using Pixel.Identity.Core.Conventions;
 using Pixel.Identity.Store.Mongo.Extensions;
@@ -88,10 +90,13 @@ namespace Pixel.Identity.Store.Mongo
             var mongoDbSettings = configuration.GetSection(nameof(MongoDbSettings)).Get<MongoDbSettings>();
             return builder.AddCore(options =>
             {
+                var mongoClientSettings = MongoClientSettings.FromConnectionString(mongoDbSettings.ConnectionString);
+                mongoClientSettings.LinqProvider = LinqProvider.V2;
+                var client = new MongoClient(mongoClientSettings);
+
                 // Configure OpenIddict to use the MongoDB stores and models.
                 options.UseMongoDb()
-               .UseDatabase(new MongoClient(mongoDbSettings.ConnectionString)
-               .GetDatabase(mongoDbSettings.DatabaseName));
+               .UseDatabase(client.GetDatabase(mongoDbSettings.DatabaseName));
 
                 //// Enable Quartz.NET integration.
                 options.UseQuartz();

--- a/src/Pixel.Identity.Store.Mongo/Pixel.Identity.Store.Mongo.csproj
+++ b/src/Pixel.Identity.Store.Mongo/Pixel.Identity.Store.Mongo.csproj
@@ -12,15 +12,15 @@
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>		
 		<PackageReference Include="Dawn.Guard" Version="1.12.0" />	
-		<PackageReference Include="MongoDB.Driver" Version="2.18.0" />
-		<PackageReference Include="OpenIddict.Abstractions" Version="4.6.0">
+		<PackageReference Include="MongoDB.Driver" Version="2.21.0" />
+		<PackageReference Include="OpenIddict.Abstractions" Version="4.7.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
+		<PackageReference Include="OpenIddict.Quartz" Version="4.7.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.MongoDb" Version="4.6.0" />
-		<PackageReference Include="OpenIddict.MongoDb.Models" Version="4.6.0" />		
+		<PackageReference Include="OpenIddict.MongoDb" Version="4.7.0" />
+		<PackageReference Include="OpenIddict.MongoDb.Models" Version="4.7.0" />		
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.PostgreSQL.csproj
+++ b/src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.PostgreSQL.csproj
@@ -14,12 +14,12 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.6.0" />
-		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.6.0" />
-		<PackageReference Include="OpenIddict.Abstractions" Version="4.6.0">
+		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.7.0" />
+		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.7.0" />
+		<PackageReference Include="OpenIddict.Abstractions" Version="4.7.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
+		<PackageReference Include="OpenIddict.Quartz" Version="4.7.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.8" />	

--- a/src/Pixel.Identity.Store.Sql.Shared/Pixel.Identity.Store.Sql.Shared.csproj
+++ b/src/Pixel.Identity.Store.Sql.Shared/Pixel.Identity.Store.Sql.Shared.csproj
@@ -14,12 +14,12 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.6.0" />
-		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.6.0" />
-		<PackageReference Include="OpenIddict.Abstractions" Version="4.6.0">
+		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.7.0" />
+		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.7.0" />
+		<PackageReference Include="OpenIddict.Abstractions" Version="4.7.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
+		<PackageReference Include="OpenIddict.Quartz" Version="4.7.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>		
 	</ItemGroup>

--- a/src/Pixel.Identity.Store.SqlServer/Pixel.Identity.Store.SqlServer.csproj
+++ b/src/Pixel.Identity.Store.SqlServer/Pixel.Identity.Store.SqlServer.csproj
@@ -14,12 +14,12 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>		
-		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.6.0" />
-		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.6.0" />
-		<PackageReference Include="OpenIddict.Abstractions" Version="4.6.0">
+		<PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.7.0" />
+		<PackageReference Include="OpenIddict.EntityFrameworkCore.Models" Version="4.7.0" />
+		<PackageReference Include="OpenIddict.Abstractions" Version="4.7.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
-		<PackageReference Include="OpenIddict.Quartz" Version="4.6.0">
+		<PackageReference Include="OpenIddict.Quartz" Version="4.7.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>		
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />

--- a/src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
+++ b/src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.37.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.37.1" />
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.37.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />


### PR DESCRIPTION
**Description**
- Updating openiddict to 4.7.0 and mongodb to 2.21.0.
- Set LinqProvider to V2 due to MongoDb issue https://jira.mongodb.org/browse/CSHARP-4535?attachmentOrder=desc 
