### PR TITLE
User registration page can be disabled for unauthorized access

### DIFF
--- a/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/Pixel.Identity.Core/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -9,8 +9,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 
 namespace Pixel.Identity.Core.Areas.Identity.Pages.Account
-{
-    [AllowAnonymous]
+{    
     [IdentityDefaultUI(typeof(RegisterModel<,>))]
     public abstract class RegisterModel : PageModel
     {

--- a/src/Pixel.Identity.Core/Controllers/UsersController.cs
+++ b/src/Pixel.Identity.Core/Controllers/UsersController.cs
@@ -2,10 +2,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using Pixel.Identity.Shared;
 using Pixel.Identity.Shared.Request;
 using Pixel.Identity.Shared.Responses;
 using Pixel.Identity.Shared.ViewModels;
+using System.Text;
+using System.Text.Encodings.Web;
 
 namespace Pixel.Identity.Core.Controllers
 {
@@ -22,16 +25,34 @@ namespace Pixel.Identity.Core.Controllers
     {
         private readonly IMapper mapper;
         private readonly UserManager<TUser> userManager;
+        private readonly IUserStore<TUser> userStore;
+        private readonly IUserEmailStore<TUser> emailStore;
+        private readonly ILogger<UsersController<TUser, TKey>> logger;
+        private readonly IEmailSender emailSender;
 
         /// <summary>
         /// constructor
         /// </summary>
         /// <param name="mapper">Implementation of <see cref="IMapper"/> for mapping models</param>
         /// <param name="userManager">Asp.Net Identity <see cref="UserManager{TUser}"/></param>
-        public UsersController(IMapper mapper, UserManager<TUser> userManager)
+        public UsersController(ILogger<UsersController<TUser, TKey>> logger, IMapper mapper, UserManager<TUser> userManager, 
+            IUserStore<TUser> userStore, IEmailSender emailSender)
         {
+            this.logger = logger;
             this.mapper = mapper;
             this.userManager = userManager;
+            this.userStore = userStore;
+            this.emailStore = GetEmailStore();
+            this.emailSender = emailSender;
+        }
+
+        IUserEmailStore<TUser> GetEmailStore()
+        {
+            if (!userManager.SupportsUserEmail)
+            {
+                throw new NotSupportedException("The default UI requires a user store with email support.");
+            }
+            return (IUserEmailStore<TUser>)userStore;
         }
 
         /// <summary>
@@ -148,6 +169,67 @@ namespace Pixel.Identity.Core.Controllers
                 return BadRequest(new BadRequestResponse(result.GetErrors()));
             }
             return NotFound(new NotFoundResponse($"User with Id : {userId} doesn't exist"));
+        }
+
+        /// <summary>
+        /// Add a new user
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        [HttpPost()]
+        [Authorize(Policy = Policies.CanManageUsers)]
+        public async Task<IActionResult> AddUserAsync(RegisterViewModel model)
+        {
+            if(ModelState.IsValid)
+            {
+                var user = CreateUser();
+
+                await userStore.SetUserNameAsync(user, model.Email, CancellationToken.None);
+                await emailStore.SetEmailAsync(user, model.Email, CancellationToken.None);
+                var result = await userManager.CreateAsync(user, model.Password);
+
+                if (result.Succeeded)
+                {
+                    logger.LogInformation("User created a new account with password.");
+
+                    var userId = await userManager.GetUserIdAsync(user);
+                    var code = await userManager.GenerateEmailConfirmationTokenAsync(user);
+                    code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+                    var callbackUrl = Url.Page(
+                        "/Account/ConfirmEmail",
+                        pageHandler: null,
+                        values: new { area = "Identity", userId = userId, code = code, returnUrl = Url.Content("~/") },
+                        protocol: Request.Scheme);
+
+                    await emailSender.SendEmailAsync(model.Email, "Confirm your email",
+                        $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+                    return Ok();
+                }
+                else
+                {
+                    foreach (var error in result.Errors)
+                    {
+                        ModelState.AddModelError(error.Code, error.Description);
+                    }
+                    return BadRequest(new BadRequestResponse(ModelState.GetValidationErrors()));
+                }
+
+            }
+            return BadRequest(new BadRequestResponse(ModelState.GetValidationErrors()));
+
+            TUser CreateUser()
+            {
+                try
+                {
+                    return Activator.CreateInstance<TUser>();
+                }
+                catch
+                {
+                    throw new InvalidOperationException($"Can't create an instance of '{nameof(TUser)}'. " +
+                        $"Ensure that '{nameof(TUser)}' is not an abstract class and has a parameterless constructor, or alternatively " +
+                        $"override the register page in /Areas/Identity/Pages/Account/Register.cshtml");
+                }
+            }
         }
 
         /// <summary>

--- a/src/Pixel.Identity.Provider/Components/LoginDisplay.razor
+++ b/src/Pixel.Identity.Provider/Components/LoginDisplay.razor
@@ -1,13 +1,18 @@
 ﻿@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+@using Microsoft.Extensions.Configuration;
+@inject IConfiguration Configuration
 
 <MudToolBar Spacing="5">
-    <MudButton id="registerPageLink" Link="authentication/register"
-               Variant="Variant.Outlined"
-               Color="Color.Tertiary" Class="mr-5">
-        Register
-    </MudButton>
-    <MudButton id="loginPageLink" Link="authentication/login"
+    @if(bool.TryParse(Configuration["AllowUserRegistration"] ?? "true", out bool allowUserRegistration) && allowUserRegistration)
+    {
+        <MudButton id="registerPageLink" Href="authentication/register"
+                   Variant="Variant.Outlined"
+                   Color="Color.Tertiary" Class="mr-5">
+            Register
+        </MudButton>
+    }    
+    <MudButton id="loginPageLink" Href="authentication/login"
                Variant="Variant.Outlined"
                Color="Color.Tertiary" Class="mr-5">
         Login

--- a/src/Pixel.Identity.Provider/Startup.cs
+++ b/src/Pixel.Identity.Provider/Startup.cs
@@ -50,7 +50,19 @@ namespace Pixel.Identity.Provider
 
             //Add plugin assembly type to application part so that controllers in this assembly can be discovered by asp.net
             services.AddControllersWithViews();               
-            services.AddRazorPages();
+            services.AddRazorPages(options =>
+            {               
+                //Allow unauthorized users to access registration page when allow user registration setting is true so that users can
+                //register for a new account on their own.
+                if(bool.TryParse(Configuration["AllowUserRegistration"] ?? "true", out bool allowUserRegistration) && allowUserRegistration)
+                {
+                    options.Conventions.AllowAnonymousToAreaPage("Identity", "/Account/Register");
+                }
+                else
+                {
+                    options.Conventions.AuthorizeAreaPage("Identity", "/Account/Register", Policies.CanManageUsers);
+                }
+            });
             services.AddServerSideBlazor();
             services.AddSwaggerGen(c =>
             {

--- a/src/Pixel.Identity.Provider/appsettings.Development.json
+++ b/src/Pixel.Identity.Provider/appsettings.Development.json
@@ -12,6 +12,7 @@
         "Name": "Pixel.Identity.Store.Mongo"
       }
     ]
-  }
+  },
+  "AllowUserRegistration": true
 }
 

--- a/src/Pixel.Identity.Shared/ViewModels/RegisterViewModel.cs
+++ b/src/Pixel.Identity.Shared/ViewModels/RegisterViewModel.cs
@@ -4,20 +4,20 @@ namespace Pixel.Identity.Shared.ViewModels
 {
     public class RegisterViewModel
     {
-        [Required]       
-        public string Username { get; set; }
-
         [Required]
-        [EmailAddress]      
+        [EmailAddress]
+        [Display(Name = "Email")]
         public string Email { get; set; }
 
         [Required]
-        [StringLength(20, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
-        [DataType(DataType.Password)]   
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Password")]
         public string Password { get; set; }
 
-        [DataType(DataType.Password)]       
-        [Compare("Password", ErrorMessage = "Passwords do not match.")]
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; }
     }
 }

--- a/src/Pixel.Identity.Store.Mongo/Controllers/UsersController.cs
+++ b/src/Pixel.Identity.Store.Mongo/Controllers/UsersController.cs
@@ -3,8 +3,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using MongoDB.Bson;
+using Pixel.Identity.Core;
 using Pixel.Identity.Core.Controllers;
-using Pixel.Identity.Shared;
 using Pixel.Identity.Store.Mongo.Models;
 
 namespace Pixel.Identity.Store.Mongo.Controllers
@@ -22,8 +22,9 @@ namespace Pixel.Identity.Store.Mongo.Controllers
         /// </summary>
         /// <param name="mapper"></param>
         /// <param name="userManager"></param>
-        public UsersController(IMapper mapper, UserManager<ApplicationUser> userManager)
-            : base(mapper, userManager)
+        public UsersController(ILogger<UsersController<ApplicationUser, ObjectId>> logger, IMapper mapper, UserManager<ApplicationUser> userManager,
+            IUserStore<ApplicationUser> userStore, IEmailSender emailSender)
+            : base(logger, mapper, userManager, userStore, emailSender)
         {
         }
     }

--- a/src/Pixel.Identity.Store.Sql.Shared/Controllers/UsersController.cs
+++ b/src/Pixel.Identity.Store.Sql.Shared/Controllers/UsersController.cs
@@ -1,7 +1,7 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Pixel.Identity.Core;
 using Pixel.Identity.Core.Controllers;
 
 namespace Pixel.Identity.Store.Sql.Shared.Controllers
@@ -17,10 +17,14 @@ namespace Pixel.Identity.Store.Sql.Shared.Controllers
         /// <summary>
         /// constructor
         /// </summary>
+        /// <param name="logger"></param>
         /// <param name="mapper"></param>
         /// <param name="userManager"></param>
-        public UsersController(IMapper mapper, UserManager<ApplicationUser> userManager)
-            : base(mapper, userManager)
+        /// <param name="userStore"></param>
+        /// <param name="emailSender"></param>
+        public UsersController(ILogger<UsersController<ApplicationUser, Guid>> logger, IMapper mapper, UserManager<ApplicationUser> userManager,
+            IUserStore<ApplicationUser> userStore, IEmailSender emailSender)
+            : base(logger, mapper, userManager, userStore, emailSender)
         {
         }
     }

--- a/src/Pixel.Identity.UI.Client/Components/AddUserDialog.razor
+++ b/src/Pixel.Identity.UI.Client/Components/AddUserDialog.razor
@@ -1,0 +1,24 @@
+﻿<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            Add new user
+        </MudText>
+    </TitleContent> 
+    <DialogContent>
+        <EditForm Model="@model" OnValidSubmit="AddUserAsync">
+            <DataAnnotationsValidator />
+            <MudCard Outlined="false" Style="min-width:600px;" Elevation="0">
+                <MudCardContent>
+                    <MudTextField id="txtEmail" Label="Email" Class="mt-3" @bind-Value="model.Email" For="@(() => model.Email)" />
+                    <MudTextField id="txtPassword" Label="Password" Class="mt-3" @bind-Value="model.Password" For="@(() => model.Password)" InputType="InputType.Password" />
+                    <MudTextField id="txtConfirmPassword" Label="ConfirmPassword" Class="mt-3" @bind-Value="model.ConfirmPassword" For="@(() => model.ConfirmPassword)" InputType="InputType.Password" />
+                </MudCardContent>
+                <MudCardActions>
+                    <MudButton UserAttributes="@(new (){{"id","btnAddUser"}})"
+                               ButtonType="ButtonType.Submit" Variant="Variant.Filled"
+                               Color="Color.Primary" Class="ml-auto">Create</MudButton>
+                </MudCardActions>               
+            </MudCard>
+        </EditForm>
+    </DialogContent> 
+</MudDialog>

--- a/src/Pixel.Identity.UI.Client/Components/AddUserDialog.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Components/AddUserDialog.razor.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using Pixel.Identity.Shared.ViewModels;
+using Pixel.Identity.UI.Client.Services;
+using System.Threading.Tasks;
+
+namespace Pixel.Identity.UI.Client.Components
+{
+    /// <summary>
+    /// Dialog to create a new user
+    /// </summary>
+    public partial class AddUserDialog : ComponentBase
+    {
+        RegisterViewModel model = new RegisterViewModel();
+
+        [CascadingParameter]
+        MudDialogInstance MudDialog { get; set; }
+
+        [Inject]
+        IUsersService UsersService { get; set; }
+
+        [Inject]
+        public ISnackbar SnackBar { get; set; }
+
+        /// <summary>
+        /// Register a new user account with the application
+        /// </summary>
+        /// <returns></returns>
+        public async Task AddUserAsync()
+        {
+            var result = await UsersService.CreateUserAsync(model);
+            if (result.IsSuccess)
+            {
+                SnackBar.Add("Used created successfully.", Severity.Success);
+                MudDialog.Close(true);
+                return;
+            }
+            SnackBar.Add(result.ToString(), Severity.Error, config =>
+            {
+                config.ShowCloseIcon = true;
+                config.RequireInteraction = true;
+            });
+            MudDialog.Close(false);
+        }
+    }
+}

--- a/src/Pixel.Identity.UI.Client/Components/ApplicationForm.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Components/ApplicationForm.razor.cs
@@ -122,7 +122,7 @@ namespace Pixel.Identity.UI.Client.Components
             var parameters = new DialogParameters();
             var dialog = Dialog.Show<AddScopeDialog>("Add New Scope", parameters, new DialogOptions() { MaxWidth = MaxWidth.Large, CloseButton = true });
             var result = await dialog.Result;
-            if (!result.Cancelled && result.Data is ScopeViewModel customScope)
+            if (!result.Canceled && result.Data is ScopeViewModel customScope)
             {
                 if(Application.Permissions.Contains(customScope.Name))
                 {
@@ -141,7 +141,7 @@ namespace Pixel.Identity.UI.Client.Components
             parameters.Add("ExistingUris", Application.RedirectUris);
             var dialog = Dialog.Show<AddUriComponent>("Add New Uri", parameters, new DialogOptions() { MaxWidth = MaxWidth.Large, CloseButton = true }) ;
             var result = await dialog.Result;
-            if (!result.Cancelled && result.Data is Uri uriToAdd)
+            if (!result.Canceled && result.Data is Uri uriToAdd)
             {
                 Application.RedirectUris.Add(uriToAdd);
             }

--- a/src/Pixel.Identity.UI.Client/Pages/Users/UserList.razor
+++ b/src/Pixel.Identity.UI.Client/Pages/Users/UserList.razor
@@ -5,6 +5,9 @@
           Dense="false" Hover="true" ReadOnly="true" SortLabel="Sort By" Elevation="4" @ref="usersTable">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Users</MudText>
+        <MudIconButton UserAttributes="@(new (){{"id","btnNew"}})" Icon="@Icons.Material.Outlined.AddCircleOutline" Size="Size.Medium"
+                       @onclick="OpenNewUserDialogAsync" Color="Color.Primary"></MudIconButton>
+        <MudSpacer />
         <MudSpacer/>
         <MudTextField UserAttributes="@(new (){{"id","txtSearchBox"}})" T="string" ValueChanged="@(s=>OnSearch(s))" Placeholder="Search by User Name or Email" Adornment="Adornment.Start"
                       AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>

--- a/src/Pixel.Identity.UI.Client/Pages/Users/UserList.razor.cs
+++ b/src/Pixel.Identity.UI.Client/Pages/Users/UserList.razor.cs
@@ -2,6 +2,7 @@
 using MudBlazor;
 using Pixel.Identity.Shared.Request;
 using Pixel.Identity.Shared.ViewModels;
+using Pixel.Identity.UI.Client.Components;
 using Pixel.Identity.UI.Client.Services;
 using System.Linq;
 using System.Threading.Tasks;
@@ -76,6 +77,23 @@ namespace Pixel.Identity.UI.Client.Pages.Users
             usersTable.ReloadServerData();
         }
 
+        /// <summary>
+        /// Show a dialog to add new users
+        /// </summary>
+        async Task OpenNewUserDialogAsync()
+        {
+            var dialogReference = await DialogService.ShowAsync<AddUserDialog>("Add New User", new DialogOptions()
+            {
+                CloseButton = true,
+                CloseOnEscapeKey = true,
+                MaxWidth = MaxWidth.Medium
+            });
+            var dialogResult = await dialogReference.Result;
+            if(!dialogResult.Canceled)
+            {
+                await usersTable.ReloadServerData();
+            }
+        }
 
         /// <summary>
         /// Navigate to the edit user page

--- a/src/Pixel.Identity.UI.Client/Services/UsersService.cs
+++ b/src/Pixel.Identity.UI.Client/Services/UsersService.cs
@@ -50,6 +50,13 @@ namespace Pixel.Identity.UI.Client.Services
         Task<OperationResult> UnlockUserAccountAsync(UserDetailsViewModel userDetails);
 
         /// <summary>
+        /// Register a new user account
+        /// </summary>
+        /// <param name="registerViewModel"></param>
+        /// <returns></returns>
+        Task<OperationResult> CreateUserAsync(RegisterViewModel registerViewModel);
+
+        /// <summary>
         /// Update the details of user
         /// </summary>
         /// <param name="userDetails"></param>
@@ -120,6 +127,14 @@ namespace Pixel.Identity.UI.Client.Services
             return await OperationResult.FromResponseAsync(result);
         }
 
+        /// <inheritdoc/>
+        public async Task<OperationResult> CreateUserAsync(RegisterViewModel registerViewModel)
+        {
+            var result = await httpClient.PostAsJsonAsync<RegisterViewModel>($"api/users", registerViewModel);
+            return await OperationResult.FromResponseAsync(result);
+        }
+
+        /// <inheritdoc/>
         public async Task<OperationResult> UpdateUserAsync(UserDetailsViewModel userDetails)
         {
             var result = await httpClient.PostAsJsonAsync<UserDetailsViewModel>($"api/users/{userDetails.Id}", userDetails);

--- a/src/Pixel.Identity.UI.Tests/ComponentModels/AddUserComponent.cs
+++ b/src/Pixel.Identity.UI.Tests/ComponentModels/AddUserComponent.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.Playwright;
+using Pixel.Identity.UI.Tests.Helpers;
+using System.Threading.Tasks;
+
+namespace Pixel.Identity.UI.Tests.ComponentModels
+{
+    internal class AddUserComponent
+    {
+        private readonly IPage page;
+        private readonly DialogComponent dialogComponent;
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="page"></param>
+        public AddUserComponent(IPage page)
+        {
+            this.page = page;
+            this.dialogComponent = new DialogComponent(page);
+
+        }
+
+        /// <summary>
+        /// Fill user email and password on create new user dialog screen
+        /// </summary>
+        /// <param name="userDetails"></param>
+        /// <returns></returns>
+        public async Task FillNewUserDetails(User userDetails)
+        {            
+            var dialog = this.page.Locator("div[role='dialog']");
+            await dialog.Locator("#txtEmail").TypeAsync(userDetails.Email);
+            await dialog.Locator("#txtPassword").TypeAsync(userDetails.Password);
+            await dialog.Locator("#txtConfirmPassword").TypeAsync(userDetails.Password);
+        }
+
+        /// <summary>
+        /// Click Create button to submit the form
+        /// </summary>
+        /// <returns></returns>
+        public async Task SumbitFormAsync()
+        {
+            var dialog = this.page.Locator("div[role='dialog']");
+            await dialog.Locator("#btnAddUser").ClickAsync();
+        }
+
+        /// <summary>
+        /// Check if a given error message is displayed on form
+        /// </summary>
+        /// <param name="errorMessage"></param>
+        /// <returns></returns>
+        public async Task<bool> HasErrorMessage(string errorMessage)
+        {
+            var dialog = this.page.Locator("div[role='dialog']");
+            var errors = await dialog.Locator("div.me-auto").AllAsync();
+            foreach (var error in errors)
+            {
+               var errorDisplay = await error.TextContentAsync();
+               if(errorDisplay.Equals(errorMessage)) 
+               { 
+                    return true;
+               }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Click Create button to submit the form and close notification
+        /// </summary>
+        /// <returns>true if user was created successfully else false</returns>
+        public async Task<bool> SubmitAndCloseNotificationAsync()
+        {             
+            await page.RunAndWaitForRequestAsync(async () =>
+            {
+                var dialog = this.page.Locator("div[role='dialog']");
+                await dialog.Locator("#btnAddUser").ClickAsync();
+            }, request =>
+            {
+                return request.Url.EndsWith($"api/users/") && request.Method == "POST";
+            });
+
+            var success = await dialogComponent.EnsureSuccessAsync();
+
+            if (!success)
+            {
+                //close the claim dialog and return false indicating failure
+                await page.Locator("div[role='dialog'] button[aria-label='close'])").ClickAsync();
+            }
+            return success;
+        }
+    }
+}

--- a/src/Pixel.Identity.UI.Tests/ComponentModels/AddUserComponent.cs
+++ b/src/Pixel.Identity.UI.Tests/ComponentModels/AddUserComponent.cs
@@ -17,7 +17,6 @@ namespace Pixel.Identity.UI.Tests.ComponentModels
         {
             this.page = page;
             this.dialogComponent = new DialogComponent(page);
-
         }
 
         /// <summary>
@@ -28,9 +27,9 @@ namespace Pixel.Identity.UI.Tests.ComponentModels
         public async Task FillNewUserDetails(User userDetails)
         {            
             var dialog = this.page.Locator("div[role='dialog']");
-            await dialog.Locator("#txtEmail").TypeAsync(userDetails.Email);
-            await dialog.Locator("#txtPassword").TypeAsync(userDetails.Password);
-            await dialog.Locator("#txtConfirmPassword").TypeAsync(userDetails.Password);
+            await dialog.Locator("#txtEmail").FillAsync(userDetails.Email);
+            await dialog.Locator("#txtPassword").FillAsync(userDetails.Password);
+            await dialog.Locator("#txtConfirmPassword").FillAsync(userDetails.Password);
         }
 
         /// <summary>
@@ -41,6 +40,16 @@ namespace Pixel.Identity.UI.Tests.ComponentModels
         {
             var dialog = this.page.Locator("div[role='dialog']");
             await dialog.Locator("#btnAddUser").ClickAsync();
+        }
+
+        /// <summary>
+        /// Click Create button to submit the form
+        /// </summary>
+        /// <returns></returns>
+        public async Task CloseDialogAsync()
+        {
+            var dialog = this.page.Locator("div[role='dialog']");
+            await dialog.Locator("button[aria-label='close']").ClickAsync();
         }
 
         /// <summary>
@@ -75,17 +84,10 @@ namespace Pixel.Identity.UI.Tests.ComponentModels
                 await dialog.Locator("#btnAddUser").ClickAsync();
             }, request =>
             {
-                return request.Url.EndsWith($"api/users/") && request.Method == "POST";
+                return request.Url.EndsWith($"api/users") && request.Method == "POST";
             });
 
-            var success = await dialogComponent.EnsureSuccessAsync();
-
-            if (!success)
-            {
-                //close the claim dialog and return false indicating failure
-                await page.Locator("div[role='dialog'] button[aria-label='close'])").ClickAsync();
-            }
-            return success;
+            return await dialogComponent.EnsureSuccessAsync();           
         }
     }
 }

--- a/src/Pixel.Identity.UI.Tests/PageModels/Users/ListUsersPage.cs
+++ b/src/Pixel.Identity.UI.Tests/PageModels/Users/ListUsersPage.cs
@@ -49,7 +49,7 @@ internal class ListUsersPage : ListPage
     public async Task ShowNewUserDialogAsync()
     {
         await page.ClickAsync("#btnNew");
-        await this.page.Locator("div[role='dialog'").WaitForAsync(new LocatorWaitForOptions()
+        await this.page.Locator("div[role='dialog']").WaitForAsync(new LocatorWaitForOptions()
         {
             Timeout = 5000
         });       

--- a/src/Pixel.Identity.UI.Tests/PageModels/Users/ListUsersPage.cs
+++ b/src/Pixel.Identity.UI.Tests/PageModels/Users/ListUsersPage.cs
@@ -41,4 +41,17 @@ internal class ListUsersPage : ListPage
             });
         }
     }
+
+    /// <summary>
+    /// Click the + button to show create user dialog
+    /// </summary>
+    /// <returns></returns>
+    public async Task ShowNewUserDialogAsync()
+    {
+        await page.ClickAsync("#btnNew");
+        await this.page.Locator("div[role='dialog'").WaitForAsync(new LocatorWaitForOptions()
+        {
+            Timeout = 5000
+        });       
+    }
 }

--- a/src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
+++ b/src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.37.1" />
-    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.37.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.39.0" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.39.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Pixel.Identity.UI.Tests/Tests/UsersFixture.cs
+++ b/src/Pixel.Identity.UI.Tests/Tests/UsersFixture.cs
@@ -49,6 +49,7 @@ internal class UsersFixture : PageSesionTest
     /// </summary>
     /// <returns></returns>
     [Test, Order(10)]
+    [Ignore("Intermittently failing with user count 1 instead of user count 10 with github actions build")]
     public async Task Test_That_Can_NavigateToNext_When_Multiple_Pages_Are_Available()
     {
         var listUsersPage = new ListUsersPage(this.Page);

--- a/src/Pixel.Identity.UI.Tests/Tests/UsersFixture.cs
+++ b/src/Pixel.Identity.UI.Tests/Tests/UsersFixture.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Playwright;
 using NUnit.Framework;
+using Pixel.Identity.UI.Tests.ComponentModels;
 using Pixel.Identity.UI.Tests.Helpers;
 using Pixel.Identity.UI.Tests.NUnit;
 using Pixel.Identity.UI.Tests.PageModels;
@@ -244,5 +245,64 @@ internal class UsersFixture : PageSesionTest
         int count = await listUsersPage.GetCountAsync();
         Assert.AreEqual(0, count);
         await Expect(this.Page).ToHaveURLAsync(new Regex(".*/users/list"));
+    }
+
+    /// <summary>
+    /// Verify that create user form can't be submitted with incorrect data
+    /// </summary>
+    /// <param name="userEmail"></param>
+    /// <param name="userPassword"></param>
+    /// <param name="errorMessage"></param>
+    /// <returns></returns>
+    [Order(130)]
+    [TestCase("test_user_12@pixel.com", "", "The Password field is required.")]
+    [TestCase("", "tesT-useR-secreT-12", "The Email field is required.")]
+    public async Task Test_That_Can_Not_Submit_Create_User_Form_With_Incorrect_Details(string userEmail, string userPassword, string errorMessage)
+    {
+        var listUsersPage = new ListUsersPage(this.Page);
+        await listUsersPage.GoToAsync();
+        await listUsersPage.ShowNewUserDialogAsync();
+        var addUserComponent = new AddUserComponent(this.Page);
+        await addUserComponent.FillNewUserDetails(new User(userEmail, userPassword));
+        await addUserComponent.SumbitFormAsync();
+        Assert.IsTrue(await addUserComponent.HasErrorMessage(errorMessage));
+    }
+
+    /// <summary>
+    /// Verify that user account can be created
+    /// </summary>
+    /// <param name="userEmail"></param>
+    /// <param name="userPassword"></param>
+    /// <returns></returns>
+    [Order(130)]
+    [TestCase("test_user_12@pixel.com", "tesT-useR-secreT-12")]   
+    public async Task Test_That_Can_Create_User_Account(string userEmail, string userPassword)
+    {
+        var listUsersPage = new ListUsersPage(this.Page);
+        await listUsersPage.GoToAsync();
+        await listUsersPage.ShowNewUserDialogAsync();
+        var addUserComponent = new AddUserComponent(this.Page);
+        await addUserComponent.FillNewUserDetails(new User(userEmail, userPassword));
+        bool userCreated = await addUserComponent.SubmitAndCloseNotificationAsync();
+        Assert.IsTrue(userCreated);
+    }
+
+    /// <summary>
+    /// Verify that user account can't be created with a duplicate email
+    /// </summary>
+    /// <param name="userEmail"></param>
+    /// <param name="userPassword"></param>
+    /// <returns></returns>
+    [Order(140)]
+    [TestCase("test_user_12@pixel.com", "tesT-useR-secreT-12")]
+    public async Task Test_That_Can_Not_Create_User_Account_With_Duplicate_Email(string userEmail, string userPassword)
+    {
+        var listUsersPage = new ListUsersPage(this.Page);
+        await listUsersPage.GoToAsync();
+        await listUsersPage.ShowNewUserDialogAsync();
+        var addUserComponent = new AddUserComponent(this.Page);
+        await addUserComponent.FillNewUserDetails(new User(userEmail, userPassword));
+        bool userCreated = await addUserComponent.SubmitAndCloseNotificationAsync();
+        Assert.IsFalse(userCreated);
     }
 }

--- a/src/Pixel.Identity.UI.Tests/Tests/UsersFixture.cs
+++ b/src/Pixel.Identity.UI.Tests/Tests/UsersFixture.cs
@@ -58,7 +58,8 @@ internal class UsersFixture : PageSesionTest
         }, request =>
         {
             return request.Url.EndsWith($"api/users?currentPage=1&pageSize=10") && request.Method == "GET";
-        });     
+        });
+        await Task.Delay(1000);
         int usersCount = await listUsersPage.GetCountAsync();
         Assert.AreEqual(10, usersCount);
         var canNavigateToNext = await listUsersPage.CanNavigateToNext();
@@ -69,7 +70,8 @@ internal class UsersFixture : PageSesionTest
         }, request =>
         {
             return request.Url.EndsWith($"api/users?currentPage=2&pageSize=10") && request.Method == "GET";
-        });     
+        });
+        await Task.Delay(1000);
         usersCount = await listUsersPage.GetCountAsync();
         Assert.AreEqual(2, usersCount);
         await Expect(this.Page).ToHaveURLAsync(new Regex(".*/users/list"));

--- a/src/Pixel.Identity.UI.Tests/Tests/UsersFixture.cs
+++ b/src/Pixel.Identity.UI.Tests/Tests/UsersFixture.cs
@@ -49,7 +49,6 @@ internal class UsersFixture : PageSesionTest
     /// </summary>
     /// <returns></returns>
     [Test, Order(10)]
-    [Ignore("Intermittently failing with user count 1 instead of user count 10 with github actions build")]
     public async Task Test_That_Can_NavigateToNext_When_Multiple_Pages_Are_Available()
     {
         var listUsersPage = new ListUsersPage(this.Page);


### PR DESCRIPTION
**Description**
It should be possible to restrict access to user registration page if admins want control over registration of users. This would be more suitable for a non-public site where it is not desirable to allow any one to register an account. Configuration key 'AllowUserRegistration' can be used to disable unauthorized access to user registration page.
Users with manage user access can create user accounts using the add user button on list users page. 