### PR TITLE
Added project to migrate mongo db to v3 from v2

### DIFF
--- a/Pixel.Identity.sln
+++ b/Pixel.Identity.sln
@@ -51,6 +51,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Identity.Store.Sql.Migrations", "src\Pixel.Identity.Store.Sql.Migrations\Pixel.Identity.Store.Sql.Migrations.csproj", "{88822DEF-9DEA-4E61-8DAE-DF387C904A1F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Migrations", "Migrations", "{74488607-BF74-48A4-95CE-F96B0292138B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pixel.Identity.Store.Mongo.Migrations", "src\Pixel.Identity.Store.Mongo.Migrations\Pixel.Identity.Store.Mongo.Migrations.csproj", "{C8DA29C9-00AB-4876-9D00-3DD306EE045E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -253,6 +257,18 @@ Global
 		{88822DEF-9DEA-4E61-8DAE-DF387C904A1F}.Release|x64.Build.0 = Release|Any CPU
 		{88822DEF-9DEA-4E61-8DAE-DF387C904A1F}.Release|x86.ActiveCfg = Release|Any CPU
 		{88822DEF-9DEA-4E61-8DAE-DF387C904A1F}.Release|x86.Build.0 = Release|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Debug|x64.Build.0 = Debug|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Debug|x86.Build.0 = Debug|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Release|x64.ActiveCfg = Release|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Release|x64.Build.0 = Release|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Release|x86.ActiveCfg = Release|Any CPU
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -263,6 +279,8 @@ Global
 		{535B958A-7CEF-43EC-9545-3CE999D74889} = {D1F9C105-5E1A-42B0-A47F-3DD3B223AD8C}
 		{440B2ECE-5DCF-481D-9C18-0EC8F4F18E98} = {90291008-5EF2-4A1F-9B89-19216A3B017F}
 		{1872169C-F107-43FD-AE02-6DDF88241644} = {2454553A-208B-4D0F-A877-66F67C550DB4}
+		{88822DEF-9DEA-4E61-8DAE-DF387C904A1F} = {74488607-BF74-48A4-95CE-F96B0292138B}
+		{C8DA29C9-00AB-4876-9D00-3DD306EE045E} = {74488607-BF74-48A4-95CE-F96B0292138B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D2D4C886-7F44-4E77-9010-D9AB3C1B559C}

--- a/src/Pixel.Identity.Store.Mongo.Migrations/Pixel.Identity.Store.Mongo.Migrations.csproj
+++ b/src/Pixel.Identity.Store.Mongo.Migrations/Pixel.Identity.Store.Mongo.Migrations.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+	<ItemGroup>	
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />	
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />	
+		<PackageReference Include="MongoDB.Driver" Version="2.23.1" />
+		<PackageReference Include="OpenIddict.Abstractions" Version="5.0.1" />		
+		<PackageReference Include="OpenIddict.MongoDb" Version="5.0.1" />
+		<PackageReference Include="OpenIddict.MongoDb.Models" Version="5.0.1" />
+	</ItemGroup>
+	<ItemGroup>
+	  <None Update="appsettings.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+</Project>

--- a/src/Pixel.Identity.Store.Mongo.Migrations/Program.cs
+++ b/src/Pixel.Identity.Store.Mongo.Migrations/Program.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using OpenIddict.MongoDb;
+
+
+using IHost host = Host.CreateDefaultBuilder(args).Build();
+var switchMappings = new Dictionary<string, string>()
+           {
+               { "--mongo-host", "mongo-host" },
+               { "--mongo-db", "mongo-db" }           };
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddCommandLine(args, switchMappings)
+    .AddJsonFile("appsettings.json", true, false)
+    .AddEnvironmentVariables()
+    .Build();
+
+string mongoServer = config.GetValue<string>("mongo-host") ?? throw new Exception("mongo-host is required");
+string mongoDb = config.GetValue<string>("mongo-db") ?? throw new Exception("mongo-db is required");
+
+var services = new ServiceCollection();
+services.AddOpenIddict()
+    .AddCore()
+    .UseMongoDb()
+    .UseDatabase(new MongoClient(mongoServer).GetDatabase(mongoDb));
+
+await using var provider = services.BuildServiceProvider();
+var context = provider.GetRequiredService<IOpenIddictMongoDbContext>();
+var options = provider.GetRequiredService<IOptionsMonitor<OpenIddictMongoDbOptions>>().CurrentValue;
+var database = await context.GetDatabaseAsync(CancellationToken.None);
+
+var applications = database.GetCollection<BsonDocument>(options.ApplicationsCollectionName);
+await applications.UpdateManyAsync(
+    filter: Builders<BsonDocument>.Filter.Empty,
+    update: Builders<BsonDocument>.Update.Rename("type", "client_type"));
+
+Console.WriteLine("Completed !!");

--- a/src/Pixel.Identity.Store.Mongo.Migrations/appsettings.json
+++ b/src/Pixel.Identity.Store.Mongo.Migrations/appsettings.json
@@ -1,0 +1,4 @@
+{
+  "mongo-host": "mongodb://localhost:27017",
+  "mongo-db":  "pixel-identity-db-test"
+}


### PR DESCRIPTION
**Description**
OpenIdDict v5 requires type field to be renamed to client_type. Console app can be used to rename the type field to client_type for mongo db -> application when migrating from v2 to v3.