### PR TITLE
Optional migration and no auto db creation

### DIFF
--- a/.config/identity-postgres-with-console-email.env
+++ b/.config/identity-postgres-with-console-email.env
@@ -3,6 +3,7 @@
 #Admin account to create on initialize
 InitAdminUser=admin@pixel.com
 InitAdminUserPass=Admi9@pixel
+AutoMigrate=true
 
 #Plugin configuration
 Plugins__Collection__0__Type=EmailSender

--- a/src/Pixel.Identity.Store.PostgreSQL/SqlConfigurator.cs
+++ b/src/Pixel.Identity.Store.PostgreSQL/SqlConfigurator.cs
@@ -37,7 +37,8 @@ public class SqlConfigurator : IDataStoreConfigurator
 
         return services.AddDbContext<ApplicationDbContext>(options =>
         {
-            options.UseNpgsql(configuration.GetConnectionString("PostgreServerConnection"));
+            options.UseNpgsql(configuration.GetConnectionString("PostgreServerConnection"), 
+                x => x.MigrationsAssembly("Pixel.Identity.Store.PostgreSQL"));
 
             // Register the entity sets needed by OpenIddict.
             // Note: use the generic overload if you need

--- a/src/Pixel.Identity.Store.SqlServer/SqlConfigurator.cs
+++ b/src/Pixel.Identity.Store.SqlServer/SqlConfigurator.cs
@@ -37,7 +37,8 @@ public class SqlConfigurator : IDataStoreConfigurator
 
         return services.AddDbContext<ApplicationDbContext>(options =>
         {
-            options.UseSqlServer(configuration.GetConnectionString("SqlServerConnection"));
+            options.UseSqlServer(configuration.GetConnectionString("SqlServerConnection"),
+                x => x.MigrationsAssembly("Pixel.Identity.Store.SqlServer"));
 
             // Register the entity sets needed by OpenIddict.
             // Note: use the generic overload if you need

--- a/src/Pixel.Identity.UI.Tests/PageModels/RegisterPage.cs
+++ b/src/Pixel.Identity.UI.Tests/PageModels/RegisterPage.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Playwright;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Pixel.Identity.UI.Tests.PageModels
@@ -23,6 +24,11 @@ namespace Pixel.Identity.UI.Tests.PageModels
         public async Task GoToAsync()
         {           
             await page.ClickAsync("#registerPageLink");
+            await page.WaitForURLAsync(new System.Text.RegularExpressions.Regex(".*/Account/Register/*"), new PageWaitForURLOptions()
+            {
+                WaitUntil = WaitUntilState.NetworkIdle,
+                Timeout = 60000
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
**Description**
Removed call for context.Database.EnsureCreatedAsync(); so that database is not created automatically. A new configuration flag 'AutoMigrate' is added with default value of false that can apply migrations automatically. This will be useful for dev/ci-cd environments and to quickly spin up containers. SQL migration scripts should be used for actual production use case.