### PR TITLE
Upload test cases even if tests fail

### DIFF
--- a/.github/workflows/identity-test-docker-image-with-mongo.yaml
+++ b/.github/workflows/identity-test-docker-image-with-mongo.yaml
@@ -46,6 +46,7 @@ jobs:
        run: dotnet test  --logger "trx;" src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
      - name: Upload test results
        uses: actions/upload-artifact@v3
+       if: ${{ always() }}
        with:
         name: pixel-identity-mongo-automation-test-results-${{ matrix.os }}
         path: src/Pixel.Identity.UI.Tests/TestResults/*.trx  

--- a/.github/workflows/identity-test-docker-image-with-postgres.yaml
+++ b/.github/workflows/identity-test-docker-image-with-postgres.yaml
@@ -52,6 +52,7 @@ jobs:
        run: dotnet test  --logger "trx;" src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
      - name: Upload test results
        uses: actions/upload-artifact@v3
+       if: ${{ always() }}
        with:
         name: pixel-identity-postgres-automation-test-results-${{ matrix.os }}
         path: src/Pixel.Identity.UI.Tests/TestResults/*.trx  


### PR DESCRIPTION
**Description**
If any of the test cases fail, the upload artifact doesn't upload the test results file. This is because it doesn't run by design if the previous step failed. We need to setup it to always run so that in can upload test results even when tests fail.