### PR TITLE
Map result to ApplicationViewModel while returning result from Create application

### DIFF
--- a/src/Pixel.Identity.Core/Controllers/ApplicationsController.cs
+++ b/src/Pixel.Identity.Core/Controllers/ApplicationsController.cs
@@ -71,7 +71,7 @@ namespace Pixel.Identity.Core.Controllers
                 {
                     await AllowOriginsAsync(applicationDescriptor.RedirectUris);
                 }
-                return CreatedAtAction(nameof(Get), new { clientId = applicationDescriptor.ClientId }, result);
+                return CreatedAtAction(nameof(Get), new { clientId = applicationDescriptor.ClientId }, mapper.Map<ApplicationViewModel>(result));
             }
             return BadRequest(new BadRequestResponse(ModelState.GetValidationErrors()));
         }


### PR DESCRIPTION
**Description**
Result of IOpenIddictApplicationManager->CreateAsync fails to deserialize if JsonWebKeySet has a value. We need to map it to ApplicationViewModel for mapping correctly just like in Get calls.