### PR TITLE
Fix link to profile page from the login status display on top right

### DIFF
--- a/src/Pixel.Identity.UI.Client/Shared/LoginDisplay.razor
+++ b/src/Pixel.Identity.UI.Client/Shared/LoginDisplay.razor
@@ -10,7 +10,7 @@
                 <MudAvatar>@context.User.Identity.Name.First()</MudAvatar>
             </ActivatorContent>
             <ChildContent>
-                <MudMenuItem id="profileMenuItem" Href="./authentication/profile">Profile</MudMenuItem>
+                <MudMenuItem id="profileMenuItem" Href="./account/profile">Profile</MudMenuItem>
                 <MudMenuItem id="signOutMenuItem" @onclick="BeginSignOut">Sign Out</MudMenuItem>
             </ChildContent>
         </MudMenu>


### PR DESCRIPTION
Fix link to profile page from the login status display on top right